### PR TITLE
Image, Avatar, AvatarGroup 공통 컴포넌트 구현

### DIFF
--- a/src/components/shared/Avatar/Avatar.styles.ts
+++ b/src/components/shared/Avatar/Avatar.styles.ts
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+import { Image } from '@components/shared/Image';
+
+import { AvatarProps } from './Avatar';
+
+export const StyledImage = styled(Image)<AvatarProps>`
+  border: ${({ border }) => border};
+  border-radius: ${({ radius }) => radius};
+`;

--- a/src/components/shared/Avatar/Avatar.tsx
+++ b/src/components/shared/Avatar/Avatar.tsx
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from 'react';
+
 import { StyledImage } from './Avatar.styles';
 
 export type AvatarProps = {
@@ -5,20 +7,17 @@ export type AvatarProps = {
   size?: number;
   radius?: string;
   border?: string;
-  style?: React.CSSProperties;
-};
+} & HTMLAttributes<HTMLImageElement>;
 
 export const Avatar = ({
   src,
   size = 30,
   radius = '50%',
   border,
-  style,
   ...props
 }: AvatarProps) => {
   return (
     <StyledImage
-      style={style}
       src={src}
       alt="avatar"
       width={size}

--- a/src/components/shared/Avatar/Avatar.tsx
+++ b/src/components/shared/Avatar/Avatar.tsx
@@ -1,0 +1,30 @@
+import { StyledImage } from './Avatar.styles';
+
+export type AvatarProps = {
+  src: string;
+  size?: number;
+  radius?: string;
+  border?: string;
+  style?: React.CSSProperties;
+};
+
+export const Avatar = ({
+  src,
+  size = 30,
+  radius = '50%',
+  border,
+  style,
+  ...props
+}: AvatarProps) => {
+  return (
+    <StyledImage
+      style={style}
+      src={src}
+      alt="avatar"
+      width={size}
+      border={border}
+      radius={radius}
+      {...props}
+    />
+  );
+};

--- a/src/components/shared/Avatar/index.ts
+++ b/src/components/shared/Avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './Avatar';

--- a/src/components/shared/AvatarGroup/AvatarGroup.styles.ts
+++ b/src/components/shared/AvatarGroup/AvatarGroup.styles.ts
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+
+import { Avatar, AvatarProps } from '@components/shared/Avatar';
+
+import { AvatarGroupProps } from './AvatarGroup';
+
+type AvatarGroupWrapperProps = Required<Pick<AvatarGroupProps, 'overlap'>>;
+
+export const AvatarGroupWrapper = styled.div<AvatarGroupWrapperProps>`
+  padding-left: ${({ overlap }) => `${overlap / 16}rem`};
+`;
+
+export const OverlapedAvatar = styled(Avatar)<
+  AvatarProps & { overlap: number }
+>`
+  margin-left: ${({ overlap }) => `-${overlap / 16}rem`};
+`;

--- a/src/components/shared/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/shared/AvatarGroup/AvatarGroup.tsx
@@ -1,0 +1,45 @@
+import React, { HTMLAttributes } from 'react';
+
+import { Avatar, AvatarProps } from '../Avatar';
+import { AvatarGroupWrapper, OverlapedAvatar } from './AvatarGroup.styles';
+
+export type AvatarGroupProps = {
+  children: React.ReactNode;
+  overlap?: number;
+} & Omit<AvatarProps, 'src'> &
+  HTMLAttributes<HTMLDivElement>;
+
+export const AvatarGroup = ({
+  children,
+  size = 30,
+  radius = '50%',
+  border,
+  overlap = 10,
+  ...props
+}: AvatarGroupProps) => {
+  const avatars = React.Children.toArray(children)
+    .filter((element): element is React.ReactElement<AvatarProps> => {
+      if (!React.isValidElement(element)) {
+        return false;
+      }
+      if (element.type !== Avatar) {
+        return false;
+      }
+      return true;
+    })
+    .map(({ props: { src } }) => (
+      <OverlapedAvatar
+        src={src}
+        size={size}
+        border={border}
+        radius={radius}
+        overlap={overlap}
+      />
+    ));
+
+  return (
+    <AvatarGroupWrapper overlap={overlap} {...props}>
+      {avatars}
+    </AvatarGroupWrapper>
+  );
+};

--- a/src/components/shared/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/shared/AvatarGroup/AvatarGroup.tsx
@@ -27,9 +27,9 @@ export const AvatarGroup = ({
       }
       return true;
     })
-    .map(({ props: { src } }) => (
+    .map(({ props }) => (
       <OverlapedAvatar
-        src={src}
+        {...props}
         size={size}
         border={border}
         radius={radius}

--- a/src/components/shared/AvatarGroup/index.ts
+++ b/src/components/shared/AvatarGroup/index.ts
@@ -1,0 +1,1 @@
+export * from './AvatarGroup';

--- a/src/components/shared/Image/Image.styles.ts
+++ b/src/components/shared/Image/Image.styles.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+import { ImageCustomProps } from './Image';
+
+type ImgProps = Required<ImageCustomProps>;
+
+export const Img = styled.img<ImgProps>`
+  display: ${({ block }) => (block ? 'block' : 'inline')};
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  object-fit: ${({ mode }) => mode};
+`;

--- a/src/components/shared/Image/Image.tsx
+++ b/src/components/shared/Image/Image.tsx
@@ -1,0 +1,40 @@
+import { CSSProperties, HTMLAttributes } from 'react';
+
+import { Img } from './Image.styles';
+
+export type ImageCustomProps = {
+  src: string;
+  block?: boolean;
+  width: number | string;
+  height?: number | string;
+  alt: string;
+  mode?: CSSProperties['objectFit'];
+};
+type ImageProps = ImageCustomProps & HTMLAttributes<HTMLImageElement>;
+
+export const Image = ({
+  src,
+  block = false,
+  width,
+  height = width,
+  alt,
+  mode = 'cover',
+  ...props
+}: ImageProps) => {
+  const stringifiedWidth =
+    typeof width === 'number' ? `${width / 16}rem` : width;
+  const stringifiedHeight =
+    typeof height === 'number' ? `${height / 16}rem` : height;
+
+  return (
+    <Img
+      src={src}
+      alt={alt}
+      width={stringifiedWidth}
+      height={stringifiedHeight}
+      block={block}
+      mode={mode}
+      {...props}
+    />
+  );
+};

--- a/src/components/shared/Image/index.ts
+++ b/src/components/shared/Image/index.ts
@@ -1,0 +1,1 @@
+export * from './Image';


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
[feat: Image 공통 컴포넌트 구현](https://github.com/Java-and-Script/pickple-front/commit/5b470af3060ba8b27f23924dc8bec2b97422e738)
[feat: Avatar 공통 컴포넌트 구현](https://github.com/Java-and-Script/pickple-front/commit/36b2942b229f4f5114c85b18e6e0d048da2a3016)
[feat: AvatarGroup 공통 컴포넌트 구현](https://github.com/Java-and-Script/pickple-front/commit/fbcb46662a18fa1ffc42ff7da31ae7a62d4614a3)

## 👨‍💻 구현 내용 or 👍 해결
<img width="340" alt="스크린샷 2023-10-28 오후 9 24 41" src="https://github.com/Java-and-Script/pickple-front/assets/81508534/d4a65b7e-1e5e-4d34-9e8c-c4d37edb9ef4">

### code
```tsx
<AvatarGroup
  size={30}
  radius="50%"
  border={`1px solid ${PALETTE.GRAY_400}`}
  overlap={10}
>
  <Avatar src="https://picsum.photos/500" />
  <Avatar src="https://picsum.photos/500" />
  <Avatar src="https://picsum.photos/500" />
  <Avatar src="https://picsum.photos/500" />
  <Avatar src="https://picsum.photos/500" />
</AvatarGroup>
```
<img width="321" alt="스크린샷 2023-10-28 오후 9 30 21" src="https://github.com/Java-and-Script/pickple-front/assets/81508534/e31e501b-3bf7-4d18-ab6c-b214e4c2e7d2">

### code

```tsx
import Ball from '@assets/ball.svg';

<Avatar src={Ball} size={100} radius="16px" border="2px solid black" />
```

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항
Image 컴포넌트의 width, height값을 number로 받을 시 내부에서 rem으로 변경됩니다.
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->
#23 close
#24 close

<!--## 완료 사항-->
