### PR TITLE
하단 모달 슬라이드 컴포넌트 구현

### DIFF
--- a/src/components/shared/ModalBottomSheet.tsx
+++ b/src/components/shared/ModalBottomSheet.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import { useBottomSheet } from '@hooks/useBottomSheet';
+
+type ModalBottomProps = {
+  children: React.ReactNode;
+  setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const StyledDeemBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.PALETTE.GRAY_900};
+  opacity: 0.5;
+`;
+
+const StyledBottomSheet = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 75%;
+  ${({ theme }) => theme.STYLES.FLEX_CENTER}
+  flex-direction: column;
+  background-color: white;
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+  animation: bottom-sheet-up 0.2s ease-in-out;
+`;
+
+const StyledModalHeader = styled.div`
+  position: absolute;
+  top: 0.69rem;
+  width: 3.125rem;
+  height: 0.1875rem;
+  background-color: ${({ theme }) => theme.PALETTE.GRAY_300};
+`;
+
+const StyledModalBottom = styled.div`
+  @keyframes bottom-sheet-up {
+    0% {
+      transform: translateY(100%);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes bottom-sheet-down {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(100%);
+    }
+  }
+`;
+
+const BottomSheet = ({ children }: { children: React.ReactNode }) => {
+  return <StyledBottomSheet>{children}</StyledBottomSheet>;
+};
+
+export const ModalBottomSheet = (props: ModalBottomProps) => {
+  const [isModalVisible, setIsModalVisible] = useState(true);
+
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    const handleScroll = () => {
+      if (window.scrollY < 0) {
+        setIsModalVisible(false);
+      }
+    };
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node)
+      ) {
+        setIsModalVisible(false);
+        props.setShowModal(false);
+
+        modalRef.current.style.animation = 'bottom-sheet-down 0.2s ease-in-out';
+        modalRef.current.style.transform = 'translateY(100%)';
+
+        setTimeout(() => {
+          setIsModalVisible(false);
+        }, 200);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.body.style.overflow = 'unset';
+    };
+  }, [props]);
+
+  const { handleTouchStart, handleTouchMove, handleTouchEnd } = useBottomSheet(
+    () => {
+      setIsModalVisible(false);
+      props.setShowModal(false);
+    }
+  );
+
+  return (
+    <StyledModalBottom>
+      {isModalVisible && (
+        <>
+          <StyledDeemBackground />
+          <div
+            ref={modalRef}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+          >
+            <BottomSheet {...props}>
+              <StyledModalHeader />
+              {props.children}
+            </BottomSheet>
+          </div>
+        </>
+      )}
+    </StyledModalBottom>
+  );
+};

--- a/src/components/shared/ModalBottomSheet.tsx
+++ b/src/components/shared/ModalBottomSheet.tsx
@@ -61,17 +61,17 @@ const StyledModalBottom = styled.div`
   }
 `;
 
-const BottomSheet = ({ children }: { children: React.ReactNode }) => {
-  return <StyledBottomSheet>{children}</StyledBottomSheet>;
-};
+const BottomSheet = ({ children }: { children: React.ReactNode }) => (
+  <StyledBottomSheet>{children}</StyledBottomSheet>
+);
 
 export const ModalBottomSheet = (props: ModalBottomProps) => {
   const [isModalVisible, setIsModalVisible] = useState(true);
-
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
+
     const handleScroll = () => {
       if (window.scrollY < 0) {
         setIsModalVisible(false);
@@ -86,8 +86,11 @@ export const ModalBottomSheet = (props: ModalBottomProps) => {
         setIsModalVisible(false);
         props.setShowModal(false);
 
-        modalRef.current.style.animation = 'bottom-sheet-down 0.2s ease-in-out';
-        modalRef.current.style.transform = 'translateY(100%)';
+        if (modalRef.current.style) {
+          modalRef.current.style.animation =
+            'bottom-sheet-down 0.2s ease-in-out';
+          modalRef.current.style.transform = 'translateY(100%)';
+        }
 
         setTimeout(() => {
           setIsModalVisible(false);
@@ -119,8 +122,8 @@ export const ModalBottomSheet = (props: ModalBottomProps) => {
           <StyledDeemBackground />
           <div
             ref={modalRef}
-            onTouchStart={handleTouchStart}
-            onTouchMove={handleTouchMove}
+            onTouchStart={() => handleTouchStart}
+            onTouchMove={() => handleTouchMove}
             onTouchEnd={handleTouchEnd}
           >
             <BottomSheet {...props}>

--- a/src/components/shared/ModalBottomSheet.tsx
+++ b/src/components/shared/ModalBottomSheet.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import { useBottomSheet } from '@hooks/useBottomSheet';
 
-type ModalBottomProps = {
+type ModalBottomSheetProps = {
   children: React.ReactNode;
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -25,7 +25,7 @@ const StyledBottomSheet = styled.div`
   left: 0;
   width: 100%;
   height: 75%;
-  ${({ theme }) => theme.STYLES.FLEX_CENTER}
+  ${({ theme }) => theme.STYLES.FLEX_CENTER};
   flex-direction: column;
   background-color: white;
   border-top-left-radius: 0.75rem;
@@ -65,7 +65,7 @@ const BottomSheet = ({ children }: { children: React.ReactNode }) => (
   <StyledBottomSheet>{children}</StyledBottomSheet>
 );
 
-export const ModalBottomSheet = (props: ModalBottomProps) => {
+export const ModalBottomSheet = (props: ModalBottomSheetProps) => {
   const [isModalVisible, setIsModalVisible] = useState(true);
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -115,22 +115,24 @@ export const ModalBottomSheet = (props: ModalBottomProps) => {
     }
   );
 
+  const BottomSheetContainer = styled.div``;
+
   return (
     <StyledModalBottom>
       {isModalVisible && (
         <>
           <StyledDeemBackground />
-          <div
+          <BottomSheetContainer
             ref={modalRef}
-            onTouchStart={() => handleTouchStart}
-            onTouchMove={() => handleTouchMove}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
           >
             <BottomSheet {...props}>
               <StyledModalHeader />
               {props.children}
             </BottomSheet>
-          </div>
+          </BottomSheetContainer>
         </>
       )}
     </StyledModalBottom>

--- a/src/components/shared/ModalBottomSheet/ModalBottomSheet.styles.ts
+++ b/src/components/shared/ModalBottomSheet/ModalBottomSheet.styles.ts
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+
+export const StyledDeemBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.PALETTE.GRAY_900};
+  opacity: 0.5;
+`;
+
+export const StyledBottomSheet = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 75%;
+  ${({ theme }) => theme.STYLES.FLEX_CENTER};
+  flex-direction: column;
+  background-color: white;
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+  animation: bottom-sheet-up 0.2s ease-in-out;
+`;
+
+export const StyledModalHeader = styled.div`
+  position: absolute;
+  top: 0.69rem;
+  width: 3.125rem;
+  height: 0.1875rem;
+  background-color: ${({ theme }) => theme.PALETTE.GRAY_300};
+`;
+
+export const StyledModalBottom = styled.div`
+  @keyframes bottom-sheet-up {
+    0% {
+      transform: translateY(100%);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes bottom-sheet-down {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(100%);
+    }
+  }
+`;
+
+export const BottomSheetContainer = styled.div``;

--- a/src/components/shared/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/src/components/shared/ModalBottomSheet/ModalBottomSheet.tsx
@@ -1,65 +1,19 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-import styled from '@emotion/styled';
-
 import { useBottomSheet } from '@hooks/useBottomSheet';
+
+import {
+  BottomSheetContainer,
+  StyledBottomSheet,
+  StyledDeemBackground,
+  StyledModalBottom,
+  StyledModalHeader,
+} from './ModalBottomSheet.styles';
 
 type ModalBottomSheetProps = {
   children: React.ReactNode;
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
-
-const StyledDeemBackground = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: ${({ theme }) => theme.PALETTE.GRAY_900};
-  opacity: 0.5;
-`;
-
-const StyledBottomSheet = styled.div`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 75%;
-  ${({ theme }) => theme.STYLES.FLEX_CENTER};
-  flex-direction: column;
-  background-color: white;
-  border-top-left-radius: 0.75rem;
-  border-top-right-radius: 0.75rem;
-  animation: bottom-sheet-up 0.2s ease-in-out;
-`;
-
-const StyledModalHeader = styled.div`
-  position: absolute;
-  top: 0.69rem;
-  width: 3.125rem;
-  height: 0.1875rem;
-  background-color: ${({ theme }) => theme.PALETTE.GRAY_300};
-`;
-
-const StyledModalBottom = styled.div`
-  @keyframes bottom-sheet-up {
-    0% {
-      transform: translateY(100%);
-    }
-    100% {
-      transform: translateY(0);
-    }
-  }
-
-  @keyframes bottom-sheet-down {
-    0% {
-      transform: translateY(0);
-    }
-    100% {
-      transform: translateY(100%);
-    }
-  }
-`;
 
 const BottomSheet = ({ children }: { children: React.ReactNode }) => (
   <StyledBottomSheet>{children}</StyledBottomSheet>
@@ -114,8 +68,6 @@ export const ModalBottomSheet = (props: ModalBottomSheetProps) => {
       props.setShowModal(false);
     }
   );
-
-  const BottomSheetContainer = styled.div``;
 
   return (
     <StyledModalBottom>

--- a/src/components/shared/ModalBottomSheet/index.ts
+++ b/src/components/shared/ModalBottomSheet/index.ts
@@ -1,0 +1,1 @@
+export * from './ModalBottomSheet';

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -1,0 +1,30 @@
+import { useCallback, useRef } from 'react';
+
+export const useBottomSheet = (closeModal: () => void) => {
+  const record = useRef({
+    first: 0,
+    move: 0,
+  });
+
+  const handleTouchStart = (event: TouchEvent) => {
+    record.current.first = event.touches[0].screenY;
+  };
+
+  const handleTouchMove = useCallback((event: TouchEvent) => {
+    if (!record.current.move) {
+      record.current.move = event.touches[0].screenY;
+    }
+  }, []);
+
+  const handleTouchEnd = () => {
+    if (record.current.first !== null && record.current.move !== null) {
+      if (record.current.first < record.current.move) {
+        closeModal();
+      }
+    }
+    record.current.first = 0;
+    record.current.move = 0;
+  };
+
+  return { handleTouchStart, handleTouchMove, handleTouchEnd };
+};

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -6,11 +6,11 @@ export const useBottomSheet = (closeModal: () => void) => {
     move: 0,
   });
 
-  const handleTouchStart = (event: TouchEvent) => {
+  const handleTouchStart = (event: React.TouchEvent) => {
     record.current.first = event.touches[0].screenY;
   };
 
-  const handleTouchMove = useCallback((event: TouchEvent) => {
+  const handleTouchMove = useCallback((event: React.TouchEvent) => {
     if (!record.current.move) {
       record.current.move = event.touches[0].screenY;
     }


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
하단에서 올라오는 모달 구현했습니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
하단 모달 슬라이드 컴포넌트를 렌더링하면 아래에서 위로 애니메이션과 함께 화면에 출력됩니다.
모달 슬라이드 내부에 원하는 컴포넌트를 child로 렌더링 할 수 있습니다.
모달 밖 영역을 클릭하면 모달이 닫힙니다.
모달을 위에서 아래로 스크롤하면 모달이 닫힙니다. - 이를 위해서 커스텀 훅을 구현했습니다.

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<img width="326" alt="스크린샷 2023-10-29 오후 8 34 47" src="https://github.com/Java-and-Script/pickple-front/assets/71740032/b2380612-1ba1-480c-819f-a3c6c7bf7cc7">

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

모달이 사라질 때 아래로 사라지는 애니메이션은 구현하지 못했습니다.
## 🎯 PR 포인트

사용 예시
```tsx
import { ModalBottomSheet } from '@components/shared/ModalBottomSheet';

const Page = () => {
  // 모달 표시할 여부, 모달 표시할 여부 set함수
  const [showModal, setShowModal] = useState(false);
    return (
	<>
	  {showModal && (
		<ModalBottomSheet setShowModal={setShowModal}>
		    <Component /> // Modal 안에 표시할 컴포넌트
		</ModalBottomSheet>
	  )}
	</>
    )
}
```

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
수정할 부분 있으면 알려주세요!
모달이 사라질 때 아래로 사라지는 애니메이션 구현 방법 알고 있으시면 알려주세요!
## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->
#27 close
<!--## 완료 사항-->
