### PR TITLE
Login api mocking 수정

### DIFF
--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,12 +1,12 @@
 import { InternalAxiosRequestConfig } from 'axios';
 
 export const setAuthorization = (config: InternalAxiosRequestConfig) => {
-  const stringifiedAccssToken = localStorage.getItem('ACCESS_TOKEN');
-  if (!stringifiedAccssToken) {
+  const stringifiedAccessToken = localStorage.getItem('ACCESS_TOKEN');
+  if (!stringifiedAccessToken) {
     return config;
   }
 
-  const accessToken = JSON.parse(stringifiedAccssToken);
+  const { accessToken } = JSON.parse(stringifiedAccessToken);
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
   }

--- a/src/api/member/getConfirmedGames.ts
+++ b/src/api/member/getConfirmedGames.ts
@@ -1,14 +1,11 @@
 import { axiosInstance } from '@api/axiosInstance';
 
-import {
-  GetConfiremdGamesRequest,
-  GetConfiremdGamesResponse,
-} from '@type/api/member';
+import { GetConfirmedGamesRequest } from '@type/api/member';
 
 export const getConfirmedGames = async ({
   memberId,
-}: GetConfiremdGamesRequest) => {
-  const { data } = await axiosInstance.get<GetConfiremdGamesResponse>(
+}: GetConfirmedGamesRequest) => {
+  const { data } = await axiosInstance.get<GetConfirmedGamesRequest>(
     `/members/${memberId}/confirmed-games`,
     {}
   );

--- a/src/hooks/queries/useConfirmGamesQuery.ts
+++ b/src/hooks/queries/useConfirmGamesQuery.ts
@@ -2,11 +2,11 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getConfirmedGames } from '@api/member/getConfirmedGames';
 
-import { GetConfiremdGamesRequest } from '@type/api/member';
+import { GetConfirmedGamesRequest } from '@type/api/member';
 
 export const useConfirmGamesQuery = ({
   memberId,
-}: GetConfiremdGamesRequest) => {
+}: GetConfirmedGamesRequest) => {
   return useSuspenseQuery({
     queryKey: ['confirmed-games', memberId],
     queryFn: () => getConfirmedGames({ memberId }),

--- a/src/hooks/queries/useLoginQuery.ts
+++ b/src/hooks/queries/useLoginQuery.ts
@@ -1,12 +1,13 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import { getLogin } from '@api/member/getLogin';
 
 import { GetLoginRequest } from '@type/api/member';
 
 export const useLoginQuery = ({ oauthProvider, authCode }: GetLoginRequest) => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ['login', oauthProvider, authCode],
-    queryFn: async () => getLogin({ oauthProvider, authCode }),
+    queryFn: () => getLogin({ oauthProvider, authCode }),
+    enabled: false,
   });
 };

--- a/src/mocks/data/member.ts
+++ b/src/mocks/data/member.ts
@@ -1,13 +1,12 @@
 import {
   GetJoinedCrewsResponse,
-  GetLoginResponse,
   GetMemberProfileResponse,
   PostRefreshAccessTokenResponse,
   PostRegistrationResponse,
 } from '@type/api/member';
-import { CrewProfile, Game } from '@type/models';
+import { Authenticated, CrewProfile, Game, Registration } from '@type/models';
 
-export const AUTH_LOGIN_MEMBER: GetLoginResponse = {
+export const AUTH_LOGIN_MEMBER: Authenticated = {
   accessToken:
     'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjk4NTA1NzM2LCJleHAiOjE2OTg1MDU4NTZ9.E0p1V4PiBDmZIZqglGjQFWh-bgbA7n7qryYnOZ3cxMuaBvp-ejkXC2b-bA5kDjZrlzyyiWuTwe-sbYk73tIR0w',
   refreshToken:
@@ -23,7 +22,7 @@ export const AUTH_LOGIN_MEMBER: GetLoginResponse = {
   addressDepth2: '영등포구',
 };
 
-export const AUTH_LOGIN_NON_MEMBER: GetLoginResponse = {
+export const AUTH_LOGIN_NON_MEMBER: Registration = {
   accessToken:
     'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjk4NTA1NzM2LCJleHAiOjE2OTg1MDU4NTZ9.E0p1V4PiBDmZIZqglGjQFWh-bgbA7n7qryYnOZ3cxMuaBvp-ejkXC2b-bA5kDjZrlzyyiWuTwe-sbYk73tIR0w',
   refreshToken: null,

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -1,100 +1,130 @@
-import { HttpResponse, http } from 'msw';
+import { DefaultBodyType, HttpResponse, PathParams, http } from 'msw';
 
-import * as DATA from '../data/member';
+import { CommonErrorResponse } from '@type/api/error';
+import {
+  GetConfirmedGamesResponse,
+  GetCreatedGamesResponse,
+  GetLoginResponse,
+  GetMemberProfileResponse,
+  PostRefreshAccessTokenResponse,
+  PostRegistrationResponse,
+} from '@type/api/member';
 
-const mockGetAuth = http.get('/api/auth/:oauthProvider', ({ params }) => {
-  console.log('register page');
+import * as DATA from '@mocks/data/member';
 
-  const { oauthProvider } = params;
-
-  if (oauthProvider !== 'KAKAO') {
-    return HttpResponse.json({}, { status: 400 });
-  }
-
-  return HttpResponse.json(DATA.MEMBERS, {
-    status: 200,
-  });
-});
-
-const mockGetLogin = http.get(
-  '/api/auth/login/:oauthProvider',
-  ({ request, params }) => {
+//TODO : mockGetAuth
+const mockGetAuth = http.get<{ oauthProvider: string }, DefaultBodyType>(
+  '/api/auth/:oauthProvider',
+  ({ params }) => {
     const { oauthProvider } = params;
 
     if (oauthProvider !== 'KAKAO') {
       return HttpResponse.json({}, { status: 400 });
     }
 
-    const url = new URL(request.url);
-    const authCode = url.searchParams.get('authCode');
-
-    if (authCode === undefined) {
-      return HttpResponse.json({}, { status: 400 });
-    }
-
-    return HttpResponse.json(DATA.AUTH_LOGIN_MEMBER, {
-      status: 201,
-    });
+    return HttpResponse.json(
+      {},
+      {
+        status: 200,
+      }
+    );
   }
 );
 
-const mockGetAuthRefresh = http.post('/api/auth/refresh', () => {
-  console.log('AuthToken Refreshed!');
+const mockGetLogin = http.get<
+  { oauthProvider: string },
+  DefaultBodyType,
+  GetLoginResponse | CommonErrorResponse
+>('/api/auth/login/:oauthProvider', ({ request, params }) => {
+  const { oauthProvider } = params;
 
+  if (oauthProvider !== 'KAKAO') {
+    return HttpResponse.json({ code: 'ADD-001' }, { status: 400 });
+  }
+
+  const url = new URL(request.url);
+  const authCode = url.searchParams.get('authCode');
+
+  if (authCode === undefined) {
+    return HttpResponse.json({ code: 'ADD-001' }, { status: 400 });
+  }
+
+  return HttpResponse.json(DATA.AUTH_LOGIN_MEMBER, {
+    status: 201,
+  });
+});
+
+const mockGetAuthRefresh = http.post<
+  PathParams,
+  DefaultBodyType,
+  PostRefreshAccessTokenResponse
+>('/api/auth/refresh', () => {
   return HttpResponse.json(DATA.ACCESS_TOKEN, {
     status: 201,
   });
 });
 
-const mockGetRegistration = http.post('/api/members', () => {
-  console.log('/members');
-
+const mockGetRegistration = http.post<
+  PathParams,
+  {
+    email: string;
+    nickname: string;
+    profileImageUrl: string;
+    positions: string[];
+    addressDepth1: string;
+    addressDepth2: string;
+    oauthId: number;
+    oauthProvider: 'KAKAO';
+  },
+  PostRegistrationResponse
+>('/api/members', () => {
   return HttpResponse.json(DATA.MEMBERS, {
     status: 201,
   });
 });
 
-const mockGetMemberProfile = http.get(
-  '/api/members/:memberId',
-  ({ params }) => {
-    const { memberId } = params;
+const mockGetMemberProfile = http.get<
+  { memberId: string },
+  DefaultBodyType,
+  GetMemberProfileResponse
+>('/api/members/:memberId', ({ params }) => {
+  const { memberId } = params;
 
-    console.log(memberId);
+  console.log(memberId);
 
-    return HttpResponse.json(DATA.MEMBERS_MEMBERID, {
-      status: 200,
-    });
-  }
-);
+  return HttpResponse.json(DATA.MEMBERS_MEMBERID, {
+    status: 200,
+  });
+});
 
-const mockGetConfirmedGames = http.get(
-  '/api/members/:memberId/confirmed-games',
-  ({ params, cookies }) => {
-    const { memberId } = params;
+const mockGetConfirmedGames = http.get<
+  { memberId: string },
+  DefaultBodyType,
+  GetConfirmedGamesResponse
+>('/api/members/:memberId/confirmed-games', ({ params }) => {
+  const { memberId } = params;
 
-    console.log(cookies);
-    // if (!cookies.accessToken) {
-    //   return new HttpResponse(null, { status: 403 });
-    // }
-    console.log(memberId);
+  console.log(memberId);
 
-    return HttpResponse.json(DATA.MEMBERS_MEMBERID_CONFIRMED_GAMES, {
-      status: 200,
-    });
-  }
-);
-const mockGetCreatedGames = http.get(
-  '/api/members/:memberId/created-games',
-  ({ params }) => {
-    const { memberId } = params;
+  return HttpResponse.json(DATA.MEMBERS_MEMBERID_CONFIRMED_GAMES, {
+    status: 200,
+  });
+});
 
-    console.log(memberId);
+const mockGetCreatedGames = http.get<
+  { memberId: string },
+  DefaultBodyType,
+  GetCreatedGamesResponse
+>('/api/members/:memberId/created-games', ({ params }) => {
+  const { memberId } = params;
 
-    return HttpResponse.json(DATA.MEMBERS_MEMBERID_CREATED_GAMES, {
-      status: 200,
-    });
-  }
-);
+  console.log(memberId);
+
+  return HttpResponse.json(DATA.MEMBERS_MEMBERID_CREATED_GAMES, {
+    status: 200,
+  });
+});
+
 const mockGetJoinedCrews = http.get(
   '/members/:memberId/joined-crews',
   ({ params }) => {

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -59,7 +59,6 @@ const mockGetMemberProfile = http.get(
   ({ params }) => {
     const { memberId } = params;
 
-    console.log('/members/:memberId');
     console.log(memberId);
 
     return HttpResponse.json(DATA.MEMBERS_MEMBERID, {
@@ -77,7 +76,6 @@ const mockGetConfirmedGames = http.get(
     // if (!cookies.accessToken) {
     //   return new HttpResponse(null, { status: 403 });
     // }
-    console.log('/members/:memberId/confirmed-games');
     console.log(memberId);
 
     return HttpResponse.json(DATA.MEMBERS_MEMBERID_CONFIRMED_GAMES, {
@@ -90,7 +88,6 @@ const mockGetCreatedGames = http.get(
   ({ params }) => {
     const { memberId } = params;
 
-    console.log('/members/:memberId/created-games');
     console.log(memberId);
 
     return HttpResponse.json(DATA.MEMBERS_MEMBERID_CREATED_GAMES, {
@@ -103,7 +100,6 @@ const mockGetJoinedCrews = http.get(
   ({ params }) => {
     const { memberId } = params;
 
-    console.log('/members/:memberId/joined-crews');
     console.log(memberId);
 
     return HttpResponse.json(DATA.MEMBERS_MEMBERID_JOINED_CREWS, {
@@ -117,7 +113,6 @@ const mockGetCreatedCrews = http.get(
   ({ params }) => {
     const { memberId } = params;
 
-    console.log('/members/:memberId/created-crews');
     console.log(memberId);
 
     return HttpResponse.json(DATA.MEMBERS_MEMBERID_CREATED_CREWS, {

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -2,7 +2,7 @@ import { HttpResponse, http } from 'msw';
 
 import * as DATA from '../data/member';
 
-const mockGetAuth = http.get('/auth/:oauthProvider', ({ params }) => {
+const mockGetAuth = http.get('/api/auth/:oauthProvider', ({ params }) => {
   console.log('register page');
 
   const { oauthProvider } = params;
@@ -17,7 +17,7 @@ const mockGetAuth = http.get('/auth/:oauthProvider', ({ params }) => {
 });
 
 const mockGetLogin = http.get(
-  '/auth/login/:oauthProvider',
+  '/api/auth/login/:oauthProvider',
   ({ request, params }) => {
     const { oauthProvider } = params;
 
@@ -32,13 +32,13 @@ const mockGetLogin = http.get(
       return HttpResponse.json({}, { status: 400 });
     }
 
-    return HttpResponse.json(DATA.ACCESS_TOKEN, {
+    return HttpResponse.json(DATA.AUTH_LOGIN_MEMBER, {
       status: 201,
     });
   }
 );
 
-const mockGetAuthRefresh = http.post('/auth/refresh', () => {
+const mockGetAuthRefresh = http.post('/api/auth/refresh', () => {
   console.log('AuthToken Refreshed!');
 
   return HttpResponse.json(DATA.ACCESS_TOKEN, {
@@ -46,7 +46,7 @@ const mockGetAuthRefresh = http.post('/auth/refresh', () => {
   });
 });
 
-const mockGetRegistration = http.post('/members', () => {
+const mockGetRegistration = http.post('/api/members', () => {
   console.log('/members');
 
   return HttpResponse.json(DATA.MEMBERS, {
@@ -54,19 +54,22 @@ const mockGetRegistration = http.post('/members', () => {
   });
 });
 
-const mockGetMemberProfile = http.get('/members/:memberId', ({ params }) => {
-  const { memberId } = params;
+const mockGetMemberProfile = http.get(
+  '/api/members/:memberId',
+  ({ params }) => {
+    const { memberId } = params;
 
-  console.log('/members/:memberId');
-  console.log(memberId);
+    console.log('/members/:memberId');
+    console.log(memberId);
 
-  return HttpResponse.json(DATA.MEMBERS_MEMBERID, {
-    status: 200,
-  });
-});
+    return HttpResponse.json(DATA.MEMBERS_MEMBERID, {
+      status: 200,
+    });
+  }
+);
 
 const mockGetConfirmedGames = http.get(
-  '/members/:memberId/confirmed-games',
+  '/api/members/:memberId/confirmed-games',
   ({ params, cookies }) => {
     const { memberId } = params;
 
@@ -83,7 +86,7 @@ const mockGetConfirmedGames = http.get(
   }
 );
 const mockGetCreatedGames = http.get(
-  '/members/:memberId/created-games',
+  '/api/members/:memberId/created-games',
   ({ params }) => {
     const { memberId } = params;
 
@@ -110,7 +113,7 @@ const mockGetJoinedCrews = http.get(
 );
 
 const mockGetCreatedCrews = http.get(
-  '/members/:memberId/created-crews',
+  '/api/members/:memberId/created-crews',
   ({ params }) => {
     const { memberId } = params;
 

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,5 +1,7 @@
 import { Header } from '@components/Header';
 
+import { useLoginQuery } from '@hooks/queries/useLoginQuery';
+
 import KAKAO_LOGIN_SRC from '@assets/kakao_login_large_wide.png';
 import LOGO_SRC from '@assets/logoSvg.svg';
 
@@ -15,6 +17,20 @@ const LOGIN_MAIN =
   'https://github.com/Java-and-Script/pickple-front/assets/87280835/1134921d-2e91-4b47-b99a-4095c91f0a6d';
 
 export const LoginPage = () => {
+  const { refetch } = useLoginQuery({
+    oauthProvider: 'KAKAO',
+    authCode: '23',
+  });
+
+  const onClickKakaoLogin = async () => {
+    const { data } = await refetch();
+    if (!data) {
+      return;
+    }
+    localStorage.setItem('LOGIN_INFO', JSON.stringify(data));
+    localStorage.setItem('ACCESS_TOKEN', data.accessToken);
+  };
+
   return (
     <LoginContainer className="hi">
       <Header isLogo={false} title="로그인" isRightContainer={false} />
@@ -31,6 +47,7 @@ export const LoginPage = () => {
           width="100%"
           height="auto"
           alt="kakao login"
+          onClick={() => onClickKakaoLogin()}
         />
       </Main>
     </LoginContainer>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -32,7 +32,7 @@ export const LoginPage = () => {
   };
 
   return (
-    <LoginContainer className="hi">
+    <LoginContainer>
       <Header isLogo={false} title="로그인" isRightContainer={false} />
       <Main>
         <LogoImage src={LOGO_SRC} width="35%" height="auto" alt="pickle logo" />

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import { Header } from '@components/Header';
 
 import { useLoginQuery } from '@hooks/queries/useLoginQuery';
@@ -17,6 +19,8 @@ const LOGIN_MAIN =
   'https://github.com/Java-and-Script/pickple-front/assets/87280835/1134921d-2e91-4b47-b99a-4095c91f0a6d';
 
 export const LoginPage = () => {
+  const navigate = useNavigate();
+
   const { refetch } = useLoginQuery({
     oauthProvider: 'KAKAO',
     authCode: '23',
@@ -24,11 +28,18 @@ export const LoginPage = () => {
 
   const onClickKakaoLogin = async () => {
     const { data } = await refetch();
+
     if (!data) {
       return;
     }
+
     localStorage.setItem('LOGIN_INFO', JSON.stringify(data));
-    localStorage.setItem('ACCESS_TOKEN', data.accessToken);
+    localStorage.setItem(
+      'ACCESS_TOKEN',
+      JSON.stringify({ accessToken: data.accessToken })
+    );
+
+    navigate(-1);
   };
 
   return (

--- a/src/type/api/member.ts
+++ b/src/type/api/member.ts
@@ -33,10 +33,11 @@ export type GetMemberProfileRequest = {
 };
 export type GetMemberProfileResponse = MemberProfile;
 
-export type GetConfiremdGamesRequest = {
+export type GetConfirmedGamesRequest = {
   memberId: Member['id'];
 };
-export type GetConfiremdGamesResponse = Game[];
+
+export type GetConfirmedGamesResponse = Game[];
 
 export type GetCreatedGamesRequest = {
   memberId: Member['id'];


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
[fix: member 관련 handlers 수정](https://github.com/Java-and-Script/pickple-front/commit/71c69ba0a52d7177ba9bca1ea385336f7d44b821) 
[feat: 로그인 임시 로직](https://github.com/Java-and-Script/pickple-front/commit/e72ef26d4ddff04906a2c6a886b15309cd26167f)
## 👨‍💻 구현 내용 or 👍 해결 내용

- 임시 로그인 로직을 추가했습니다. 로그인 버튼 클릭 시 ACCESS_TOKEN과 LOGIN_INFO이 localstorage에 저장됩니다.
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
