### PR TITLE
메인페이지 api 연동

### DIFF
--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
+import { Authenticated, Registration } from '@/type/models';
+
 import { Header } from '@components/Header';
 import { MatchItem } from '@components/MatchItem';
 import { Button } from '@components/shared/Button';
@@ -14,11 +16,32 @@ import { useMainPageNearGamesQuery } from './useMainPageNearGamesQuery';
 
 export const MainPage = () => {
   const navigate = useNavigate();
+  const localStorageInfo = localStorage.getItem('LOGIN_INFO');
+  const loginInfo: Registration | Authenticated =
+    localStorageInfo !== null
+      ? JSON.parse(localStorageInfo)
+      : {
+          accessToken:
+            'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjk4NTA1NzM2LCJleHAiOjE2OTg1MDU4NTZ9.E0p1V4PiBDmZIZqglGjQFWh-bgbA7n7qryYnOZ3cxMuaBvp-ejkXC2b-bA5kDjZrlzyyiWuTwe-sbYk73tIR0w',
+          refreshToken: null,
+          id: null,
+          nickname: '창현',
+          profileImageUrl:
+            'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg',
+          email: 'changhyeon.h@kakao.com',
+          oauthId: 32014123,
+          oauthProvider: 'KAKAO',
+          addressDepth1: null,
+          addressDepth2: null,
+        };
 
+  const { addressDepth1, addressDepth2 } = loginInfo;
   const { data } = useMainPageNearGamesQuery({
     category: 'location',
-    value: '서울시+영등포구',
+    value:
+      addressDepth1 === null ? '서울시+강남구' : addressDepth2 + addressDepth2,
   });
+  console.log(data);
 
   const filteredData = data.map(
     ({

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -10,36 +10,47 @@ import { theme } from '@styles/theme';
 import { PATH_NAME } from '@consts/pathName';
 
 import { MainPageContainer, MainPageSubContainer } from './MainPage.style';
+import { useMainPageNearGamesQuery } from './useMainPageNearGamesQuery';
 
 export const MainPage = () => {
   const navigate = useNavigate();
+
+  const { data } = useMainPageNearGamesQuery({
+    category: 'location',
+    value: '서울시+영등포구',
+  });
+
+  const filteredData = data.map(
+    ({
+      id,
+      //playStartTime,
+      playTimeMinutes,
+      mainAddress,
+      memberCount,
+      maxMemberCount,
+      members,
+    }) => (
+      <MatchItem
+        key={id.toString()}
+        matchId={id.toString()}
+        startTime={new Date()}
+        timeMinutes={playTimeMinutes}
+        mainAddress={mainAddress}
+        memberCount={memberCount}
+        maxMemberCount={maxMemberCount}
+        membersProfileImageUrls={members.map(
+          ({ profileImageUrl }) => profileImageUrl
+        )}
+      />
+    )
+  );
+
   return (
     <MainPageContainer>
       <Header isLogo={true} />
       <MainPageSubContainer>
         <Text children={'내 근처의 경기'} weight={700} size={'1.25rem'} />
-        {serverMatchItemList.map(
-          ({
-            matchId,
-            startTime,
-            timeMinutes,
-            mainAddress,
-            memberCount,
-            maxMemberCount,
-            membersProfileImageUrls,
-          }) => (
-            <MatchItem
-              key={matchId}
-              matchId={matchId}
-              startTime={startTime}
-              timeMinutes={timeMinutes}
-              mainAddress={mainAddress}
-              memberCount={memberCount}
-              maxMemberCount={maxMemberCount}
-              membersProfileImageUrls={membersProfileImageUrls}
-            />
-          )
-        )}
+        {filteredData}
         <Button
           {...MAIN_PAGE_BUTTON_PROP}
           onClick={() => navigate(PATH_NAME.GAMES_NEAR)}
@@ -49,28 +60,7 @@ export const MainPage = () => {
       </MainPageSubContainer>
       <MainPageSubContainer>
         <Text children={'추천 크루'} weight={700} size={'1.25rem'} />
-        {serverMatchItemList.map(
-          ({
-            matchId,
-            startTime,
-            timeMinutes,
-            mainAddress,
-            memberCount,
-            maxMemberCount,
-            membersProfileImageUrls,
-          }) => (
-            <MatchItem
-              key={matchId}
-              matchId={matchId}
-              startTime={startTime}
-              timeMinutes={timeMinutes}
-              mainAddress={mainAddress}
-              memberCount={memberCount}
-              maxMemberCount={maxMemberCount}
-              membersProfileImageUrls={membersProfileImageUrls}
-            />
-          )
-        )}
+        {filteredData}
         <Button {...MAIN_PAGE_BUTTON_PROP} onClick={() => console.log('hi')}>
           더보기
         </Button>
@@ -78,45 +68,6 @@ export const MainPage = () => {
     </MainPageContainer>
   );
 };
-
-const serverMatchItemList = [
-  {
-    matchId: '1',
-    startTime: new Date(),
-    timeMinutes: 60,
-    mainAddress: '',
-    memberCount: 2,
-    maxMemberCount: 8,
-    membersProfileImageUrls: [
-      'https://picsum.photos/500',
-      'https://picsum.photos/500',
-    ],
-  },
-  {
-    matchId: '2',
-    startTime: new Date(),
-    timeMinutes: 60,
-    mainAddress: '',
-    memberCount: 2,
-    maxMemberCount: 8,
-    membersProfileImageUrls: [
-      'https://picsum.photos/500',
-      'https://picsum.photos/500',
-    ],
-  },
-  {
-    matchId: '3',
-    startTime: new Date(),
-    timeMinutes: 60,
-    mainAddress: '',
-    memberCount: 2,
-    maxMemberCount: 8,
-    membersProfileImageUrls: [
-      'https://picsum.photos/500',
-      'https://picsum.photos/500',
-    ],
-  },
-];
 
 const MAIN_PAGE_BUTTON_PROP = {
   width: '100%',

--- a/src/pages/MainPage/useMainPageNearGamesQuery.ts
+++ b/src/pages/MainPage/useMainPageNearGamesQuery.ts
@@ -1,0 +1,18 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getGames } from '@api/games/getGames';
+
+const FETCH_SIZE = 3;
+
+export const useMainPageNearGamesQuery = ({
+  category,
+  value,
+}: {
+  category?: string;
+  value?: string;
+}) => {
+  return useSuspenseQuery({
+    queryKey: ['games', category, value],
+    queryFn: () => getGames({ category, value, page: 1, size: FETCH_SIZE }),
+  });
+};

--- a/src/pages/MainPage/useMainPageNearGamesQuery.ts
+++ b/src/pages/MainPage/useMainPageNearGamesQuery.ts
@@ -12,7 +12,7 @@ export const useMainPageNearGamesQuery = ({
   value?: string;
 }) => {
   return useSuspenseQuery({
-    queryKey: ['games', category, value],
+    queryKey: ['mainpage-games', category, value],
     queryFn: () => getGames({ category, value, page: 1, size: FETCH_SIZE }),
   });
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -16,7 +16,14 @@ export const router = createBrowserRouter([
     path: '/',
     element: <Layout />,
     children: [
-      { path: '', element: <MainPage /> },
+      {
+        path: '',
+        element: (
+          <Suspense fallback={null}>
+            <MainPage />
+          </Suspense>
+        ),
+      },
       { path: 'login', element: <LoginPage /> },
       { path: 'register', element: <RegisterPage /> },
       { path: 'all-services', element: <h1>all-services</h1> },


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
메인페이지에서 api를 사용해서 ui를 그리도록 변경했습니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: 메인페이지 경기 리스트 불러오는 기능 추가](https://github.com/Java-and-Script/pickple-front/commit/9c5b4801cef62d760a5799a403289d1100703815)
[feat: 메인페이지 경기 로그인 정보 이용 로직 추가](https://github.com/Java-and-Script/pickple-front/commit/4008229373fa5472c1f19910cbf6c660b5ec2af3)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<img width="950" alt="스크린샷 2023-11-03 오후 6 42 14" src="https://github.com/Java-and-Script/pickple-front/assets/120288440/45421220-5a5a-44d0-bcac-8a53e40e731e">

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->
기존에 사용하던 경기리스트를 불러오는 api가 너무 무거워서 메인 페이지에서 쓸 목적으로 쿼리를 작성했습니다. 메인페이지 폴더 안에 추가해놓았습니다.

MatchItem이 Date 객체를 사용하고있습니다.
[feat: domain 유틸함수 추가](https://github.com/Java-and-Script/pickple-front/commit/9ac622ef313513a0b1fb1ad47f4a4902f494ac0c) 머지후에 수정하겠습니다.

로그인시 근처 게임 정보를 보내고 받아오는 api가 구현이 덜 되어서 추후에 수정하도록 하겠습니다.
## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->
좀 더 읽기 좋은 코드로 만들 가능성이 있는지?

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->
#97 close
<!--## 완료 사항-->
