### PR TITLE
게스트 모집 페이지 경기 날짜 선택 캘린더 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.5.1",
         "env-cmd": "^10.1.0",
         "react": "^18.2.0",
+        "react-calendar": "^4.6.1",
         "react-dom": "^18.2.0",
         "react-draggable-bottom-sheet": "^1.14.0",
         "react-hook-form": "^7.47.0",
@@ -2210,6 +2211,19 @@
       "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
       "dev": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.200",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
+    },
+    "node_modules/@types/lodash.memoize": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.memoize/-/lodash.memoize-4.1.8.tgz",
+      "integrity": "sha512-mf2QpcedTC4qXJxqgbmCuST3a/SNTuqz2kMtojazqeLhjXaLXgoSwAgVbAz6FINw90Ahg0y1m69pm+rhta3c8Q==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "14.18.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
@@ -3214,6 +3228,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -5690,6 +5712,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.1.tgz",
+      "integrity": "sha512-VEvcsqKYx7zhZYC1CjecrDC5ziPSpl1gSm0qFFJhHSGDrSC+x4+p1KojWC/83QX//j476gFhkVXP/kNUc9q+bQ==",
+      "dependencies": {
+        "@types/lodash.memoize": "^4.1.7",
+        "lodash.memoize": "^4.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6942,6 +6976,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -8263,6 +8302,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-calendar": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-4.6.1.tgz",
+      "integrity": "sha512-MvCPdvxEvq7wICBhFxlYwxS2+IsVvSjTcmlr0Kl3yDRVhoX7btNg0ySJx5hy9rb1eaM4nDpzQcW5c87nfQ8n8w==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "prop-types": "^15.6.0",
+        "tiny-warning": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-calendar/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -9264,6 +9336,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinybench": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.5.1",
     "env-cmd": "^10.1.0",
     "react": "^18.2.0",
+    "react-calendar": "^4.6.1",
     "react-dom": "^18.2.0",
     "react-draggable-bottom-sheet": "^1.14.0",
     "react-hook-form": "^7.47.0",

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+
+import { formatDate } from '@utils/formatDate';
+
+export const CalendarComponent = ({
+  setDate,
+}: {
+  setDate: (value: string) => void;
+}) => {
+  const [value, onChange] = useState<Date>(new Date());
+  const formattedDate = formatDate(value);
+
+  useEffect(() => {
+    setDate(formattedDate);
+  }, [formattedDate, setDate]);
+
+  return (
+    <div>
+      <Calendar
+        onChange={(newDate) => {
+          onChange(newDate as Date);
+        }}
+        value={value}
+      />
+    </div>
+  );
+};

--- a/src/components/Calendar/index.ts
+++ b/src/components/Calendar/index.ts
@@ -1,0 +1,1 @@
+export * from './Calendar';

--- a/src/components/SelectPosition/SelectPosition.tsx
+++ b/src/components/SelectPosition/SelectPosition.tsx
@@ -1,0 +1,38 @@
+import { ToggleButton } from '@components/shared/ToggleButton';
+import { useToggleButtons } from '@components/shared/ToggleButton';
+
+import { Position } from '@type/models/Position';
+
+export const SelectPosition = ({
+  setPositions,
+}: {
+  setPositions: (value: Position[]) => void;
+}) => {
+  const positions = ['C', 'PF', 'SF', 'PG', 'SG', '없음'];
+
+  const handledToggle = (value: string[]) => {
+    setPositions(value as Position[]);
+  };
+
+  const { handleToggle, selectedItems } = useToggleButtons({
+    onToggle: handledToggle,
+    isMultipleSelect: true,
+  });
+
+  return (
+    <>
+      {positions.map((position) => (
+        <ToggleButton
+          type="button"
+          fontSize="12px"
+          width="47px"
+          height="32px"
+          key={position}
+          value={position}
+          isActive={selectedItems.includes(position)}
+          onToggle={handleToggle}
+        />
+      ))}
+    </>
+  );
+};

--- a/src/components/SelectPosition/index.ts
+++ b/src/components/SelectPosition/index.ts
@@ -1,0 +1,1 @@
+export * from './SelectPosition';

--- a/src/pages/CreateGamePage/CreateGamePage.tsx
+++ b/src/pages/CreateGamePage/CreateGamePage.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { CalendarComponent } from '@components/Calendar/Calendar';
 import { Header } from '@components/Header';
 import { Modal } from '@components/Modal';
+import { SelectPosition } from '@components/SelectPosition/SelectPosition';
 import { Button } from '@components/shared/Button';
 import { Text } from '@components/shared/Text';
-import { ToggleButton } from '@components/shared/ToggleButton';
-import { useToggleButtons } from '@components/shared/ToggleButton';
 import { VirtualScroll } from '@components/shared/VirtualScroll';
 
 import { useGameMutation } from '@hooks/mutations/useGameMutation';
@@ -28,40 +28,6 @@ import {
   StyledTextArea,
   StyledTitle,
 } from './CreateGamePage.styles';
-
-const PositionComponent = ({
-  setPositions,
-}: {
-  setPositions: (value: Position[]) => void;
-}) => {
-  const positions = ['C', 'PF', 'SF', 'PG', 'SG', '없음'];
-
-  const handledToggle = (value: string[]) => {
-    setPositions(value as Position[]);
-  };
-
-  const { handleToggle, selectedItems } = useToggleButtons({
-    onToggle: handledToggle,
-    isMultipleSelect: true,
-  });
-
-  return (
-    <StyledPositionsWrapper>
-      {positions.map((position) => (
-        <ToggleButton
-          type="button"
-          fontSize="12px"
-          width="47px"
-          height="32px"
-          key={position}
-          value={position}
-          isActive={selectedItems.includes(position)}
-          onToggle={handleToggle}
-        />
-      ))}
-    </StyledPositionsWrapper>
-  );
-};
 
 export const CreateGamePage = () => {
   const { mutate } = useGameMutation();
@@ -111,10 +77,6 @@ export const CreateGamePage = () => {
 
   const closeGuestCountModal = () => {
     setIsGuestCountModalOpen(false);
-  };
-
-  const handleMatchDateSelect = (item: string) => {
-    setPlayDate(item);
   };
 
   const openMatchDateModal = () => {
@@ -227,22 +189,10 @@ export const CreateGamePage = () => {
                 게스트 매치 날짜를 선택해 주세요!
               </Text>
             </StyledModalHeader>
-            <Modal.Content>
-              <VirtualScroll
-                width="100%"
-                list={[
-                  '2023년 11월 11일',
-                  '2023년 11월 12일',
-                  '2023년 11월 13일',
-                  '2023년 11월 14일',
-                  '2023년 11월 15일',
-                  '2023년 11월 16일',
-                  '2023년 11월 17일',
-                  '2023년 11월 18일',
-                  '2023년 11월 19일',
-                ]}
-                onItemSelected={handleMatchDateSelect}
-              />
+            <Modal.Content
+              style={{ display: 'flex', justifyContent: 'center' }}
+            >
+              <CalendarComponent setDate={setPlayDate} />
             </Modal.Content>
           </Modal>
           <StyledSubTitle>
@@ -334,7 +284,9 @@ export const CreateGamePage = () => {
               선호하는 포지션을 선택해 주세요!
             </Text>
           </StyledSubTitle>
-          <PositionComponent setPositions={setPositions} />
+          <StyledPositionsWrapper>
+            <SelectPosition setPositions={setPositions} />
+          </StyledPositionsWrapper>
           <StyledSubTitle>
             <Text size={16} weight={300}>
               주소를 입력해 주세요!

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,12 @@
+export const formatDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const dayOfWeek = date.toLocaleDateString('ko-KR', {
+    weekday: 'long',
+  });
+
+  const formattedDate = `${year}년 ${month}월 ${day}일 (${dayOfWeek})`;
+
+  return formattedDate;
+};


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
게스트 모집 페이지에서 경기 날짜를 선택할 때 모달에 있는 캘린더에서 날짜를 선택할 수 있습니다.

## 👨‍💻 구현 내용 or 👍 해결 내용
<img width="324" alt="스크린샷 2023-11-05 오후 1 02 00" src="https://github.com/Java-and-Script/pickple-front/assets/71740032/1dc3e871-2dda-4473-9b13-49982449ed2f">

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
react-calendar 라이브러리 사용했습니다. npm install 해주세요
포지션 선택, 날짜 선택은 컴포넌트로 분리했습니다.
Date 형식의 데이터를 원하는 String 형식으로 변환하는 util 함수도 작성했습니다.
## ❓ 궁금한 점
날짜 데이터의 문자열 형식은 임의로 작성했습니다. 
<!-- ## 이슈 번호 - close -->
#112 close
<!--## 완료 사항-->
