### PR TITLE
useGamesQuery 선택옵션값 필수로 변경

### DIFF
--- a/src/consts/location.ts
+++ b/src/consts/location.ts
@@ -25,3 +25,8 @@ export const SEOUL = {
   SONGPA_GU: '송파구',
   GANGDONG_GU: '강동구',
 } as const;
+
+export const DEFAULT_ADDRESS_DEPTHS = {
+  addressDepth1: '서울시',
+  addressDepth2: '강남구',
+} as const;

--- a/src/consts/network.ts
+++ b/src/consts/network.ts
@@ -1,0 +1,1 @@
+export const FETCH_SIZE = 20;

--- a/src/hooks/queries/useGamesQuery.ts
+++ b/src/hooks/queries/useGamesQuery.ts
@@ -2,7 +2,7 @@ import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getGames } from '@api/games/getGames';
 
-const FETCH_SIZE = 20;
+import { FETCH_SIZE } from '@consts/network';
 
 /**
  * 장소 기준 => ?category=location&value=서울시+영등포구&page=1&size=10

--- a/src/hooks/queries/useGamesQuery.ts
+++ b/src/hooks/queries/useGamesQuery.ts
@@ -10,8 +10,8 @@ import { FETCH_SIZE } from '@consts/network';
  * 포지션 기준 => ?category=positions&value=SF+SG&page=1&size=10
  * */
 export type GamesQueryProps = {
-  category?: 'location' | 'playDate' | 'position';
-  value?: string;
+  category: 'location' | 'playDate' | 'position';
+  value: string;
 };
 
 export const useGamesQuery = ({ category, value }: GamesQueryProps) => {

--- a/src/pages/GamesNearPage/GamesNearPage.tsx
+++ b/src/pages/GamesNearPage/GamesNearPage.tsx
@@ -2,11 +2,13 @@ import { Header } from '@components/Header';
 import { MatchItem } from '@components/MatchItem';
 import { Text } from '@components/shared/Text';
 
-import { GamesQueryProps, useGamesQuery } from '@hooks/queries/useGamesQuery';
+import { useGamesQuery } from '@hooks/queries/useGamesQuery';
 import { useHeaderTitle } from '@hooks/useHeaderTitle';
 import { useInfiniteScroll } from '@hooks/useInfiniteScroll';
 
 import { Member } from '@type/models';
+
+import { DEFAULT_ADDRESS_DEPTHS } from '@consts/location';
 
 import { getGameStartDate } from '@utils/domain';
 
@@ -25,13 +27,12 @@ export const GamesNearPage = () => {
   const { entryRef, showHeaderTitle } = useHeaderTitle<HTMLDivElement>();
   const myInfo = getMyInfo();
 
-  const gamesQueryProps: GamesQueryProps = myInfo
-    ? {
-        category: 'location',
-        value: `${myInfo?.addressDepth1}+${myInfo?.addressDepth2}`,
-      }
-    : {};
-  const { games, fetchNextPage } = useGamesQuery(gamesQueryProps);
+  const { games, fetchNextPage } = useGamesQuery({
+    category: 'location',
+    value: `${myInfo?.addressDepth1 || DEFAULT_ADDRESS_DEPTHS.addressDepth1}+${
+      myInfo?.addressDepth2 || DEFAULT_ADDRESS_DEPTHS.addressDepth2
+    }`,
+  });
   const lastElementRef = useInfiniteScroll<HTMLDivElement>(fetchNextPage);
 
   return (


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
useGamesQuery 선택옵션값 필수로 변경

## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: default 주소, fetch size 상수화](https://github.com/Java-and-Script/pickple-front/commit/a218bb6952b16b81053688b730e225bb805d6769)
[fix: GamesQueryProps 선택옵션들 필수로 변경](https://github.com/Java-and-Script/pickple-front/commit/244992116dbe4c3492a0f43fd73adc0ae20c5a2c)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항
기본 주소값을 상수로 빼두었습니다.
```ts
// src/consts/location.ts
...
export const DEFAULT_ADDRESS_DEPTHS = {
  addressDepth1: '서울시',
  addressDepth2: '강남구',
} as const;

```

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->
#161 close

<!--## 완료 사항-->
