### PR TITLE
게스트 모집글 생성 페이지 api 수정

### DIFF
--- a/src/mocks/handlers/game.ts
+++ b/src/mocks/handlers/game.ts
@@ -14,46 +14,45 @@ import { Game, Member } from '@type/models';
 
 import { games, pendingMembersMap } from '@mocks/data/game';
 
-const mockPostGame = http.post<
-  PathParams,
-  { data: PostGameRequest },
-  PostGameResponse
->('/api/games', async ({ request }) => {
-  const {
-    data: { hostId, ...restRequestBody },
-  } = await request.json();
-  const gameId = new Date().getTime();
+const mockPostGame = http.post<PathParams, PostGameRequest, PostGameResponse>(
+  '/api/games',
+  async ({ request }) => {
+    const data = await request.json();
 
-  const host: Member = {
-    id: Number(hostId),
-    addressDepth1: '서울시',
-    addressDepth2: '강남구',
-    email: 'example@example.com',
-    introduction: '예시 소개글입니다.',
-    mannerScore: 0,
-    mannerScoreCount: 0,
-    nickname: `testuser${hostId}`,
-    positions: [],
-    profileImageUrl: '',
-  };
+    const gameId = new Date().getTime();
+    const hostId = new Date().getTime();
 
-  const newGame: Game = {
-    id: gameId,
-    ...restRequestBody,
-    playEndTime: '00:00',
-    status: '모집 중',
-    viewCount: 0,
-    memberCount: 0,
-    host,
-    addressDepth1: '서울시',
-    addressDepth2: '강남구',
-    members: [],
-  };
+    const host: Member = {
+      id: hostId,
+      addressDepth1: '서울시',
+      addressDepth2: '강남구',
+      email: 'example@example.com',
+      introduction: '예시 소개글입니다.',
+      mannerScore: 0,
+      mannerScoreCount: 0,
+      nickname: `testuser${hostId}`,
+      positions: [],
+      profileImageUrl: '',
+    };
 
-  games.push(newGame);
+    const newGame: Game = {
+      id: gameId,
+      ...data,
+      playEndTime: '00:00',
+      status: '모집 중',
+      viewCount: 0,
+      memberCount: 0,
+      host,
+      addressDepth1: '서울시',
+      addressDepth2: '강남구',
+      members: [],
+    };
 
-  return HttpResponse.json({ gameId });
-});
+    games.push(newGame);
+
+    return HttpResponse.json({ gameId });
+  }
+);
 
 /** TODO: category, value 구현해야함 */
 const mockGetGames = http.get('/api/games', ({ request }) => {

--- a/src/pages/CreateGamePage/CreateGamePage.tsx
+++ b/src/pages/CreateGamePage/CreateGamePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 import { CalendarComponent } from '@components/Calendar';
 import { Header } from '@components/Header';
@@ -14,7 +15,10 @@ import { useHeaderTitle } from '@hooks/useHeaderTitle';
 
 import { theme } from '@styles/theme';
 
+import { Member } from '@type/models';
 import { Position } from '@type/models/Position';
+
+import { PATH_NAME } from '@consts/pathName';
 
 import {
   PageLayout,
@@ -29,7 +33,22 @@ import {
   StyledTitle,
 } from './CreateGamePage.styles';
 
+const getMyInfo = (): Member | null => {
+  const json = localStorage.getItem('LOGIN_INFO');
+  if (!json) {
+    return null;
+  }
+  return JSON.parse(json);
+};
+
 export const CreateGamePage = () => {
+  const navigate = useNavigate();
+
+  const myInfo = getMyInfo();
+  if (!myInfo) {
+    throw new Error('로그인이 필요한 서비스입니다.');
+  }
+
   const { mutate } = useGameMutation();
   const { register, handleSubmit } = useForm();
   const { entryRef, showHeaderTitle } = useHeaderTitle<HTMLDivElement>();
@@ -52,7 +71,6 @@ export const CreateGamePage = () => {
 
   const onSubmit = async () => {
     const gameData = {
-      hostId: 1,
       maxMemberCount: parseInt(maxMemberCount),
       playDate,
       playStartTime,
@@ -64,7 +82,11 @@ export const CreateGamePage = () => {
       content,
     };
 
-    mutate(gameData);
+    mutate(gameData, {
+      onSuccess: ({ gameId }) => {
+        navigate(PATH_NAME.GET_GAMES_PATH(String(gameId)));
+      },
+    });
   };
 
   const handleAddressSelect = () => {

--- a/src/type/api/games.ts
+++ b/src/type/api/games.ts
@@ -9,7 +9,6 @@ export type GetGameDetailResponse = Game;
 export type GetGameMembersResponse = Game;
 
 export type PostGameRequest = {
-  hostId: number;
   latitude?: number;
   longitude?: number;
 } & Pick<


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
[fix: PostGameRequest Type 멤버 hostId 제거](https://github.com/Java-and-Script/pickple-front/commit/cf0e747dddbe79da3cc99a23920659d0a3edf13a)
[fix: 게스트 모집글 생성 페이지 api 연동 수정](https://github.com/Java-and-Script/pickple-front/commit/0db8373a9ccd76314a619d6012b98b199e1bf163)
[fix: 게스트 모집 생성 페이지 api Mocking handler 수정](https://github.com/Java-and-Script/pickple-front/commit/a790fb6815cd844d42eb325eee8ac54271b6cc50)
## 👨‍💻 구현 내용 or 👍 해결 내용
- 게스트 모집글 생성 할 때 api request body로 넘겨 주었던 `hostId`제거 했습니다.
- 따라서 PostGameRequest Type 에서도 제거 했습니다.
- mockPostGame handler도 수정했습니다.
- 성공적으로 글이 생성되면 생성된 모집글 상세 페이지로 이동하게 구현했습니다.
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->
#166 close
<!--## 완료 사항-->
