### PR TITLE
헤더 프로필 버튼 클릭 핸들러 변경, 헤더 프로필 이미지 변경

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
+import { Avatar } from '@components/Avatar';
 import { Button } from '@components/shared/Button';
 
 import { theme } from '@styles/theme';
@@ -11,7 +12,6 @@ import { PATH_NAME } from '@consts/pathName';
 import bellIcon from '@assets/bell.svg';
 import leftArrowIcon from '@assets/leftArrow.svg';
 import logoSvg from '@assets/logoSvg.svg';
-import profileIcon from '@assets/profile.svg';
 import searchIcon from '@assets/search.svg';
 
 import {
@@ -99,7 +99,7 @@ export const Header = ({
               </RightSideIconWrapper>
               <RightSideIconWrapper>
                 <RightSideIcon onClick={() => handleProfileIconClick()}>
-                  <img src={profileIcon} alt="" />
+                  <Avatar src={loginInfo.profileImageUrl} />
                 </RightSideIcon>
               </RightSideIconWrapper>
             </RightSideContainer>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,6 +6,8 @@ import { theme } from '@styles/theme';
 
 import { useLoginInfoStore } from '@stores/loginInfo.store';
 
+import { PATH_NAME } from '@consts/pathName';
+
 import bellIcon from '@assets/bell.svg';
 import leftArrowIcon from '@assets/leftArrow.svg';
 import logoSvg from '@assets/logoSvg.svg';
@@ -36,6 +38,7 @@ export const Header = ({
   title = '',
   isRightContainer = true,
 }: Partial<HeaderProps>) => {
+  const loginInfo = useLoginInfoStore((state) => state.loginInfo);
   const navigate = useNavigate();
 
   const handleLogoClick = () => {
@@ -55,14 +58,14 @@ export const Header = ({
   };
 
   const handleProfileIconClick = () => {
-    navigate('/all-services');
+    if (loginInfo?.id) {
+      navigate(PATH_NAME.GET_PROFILE_PATH(String(loginInfo.id)));
+    }
   };
 
   const handleLoginClick = () => {
-    navigate('/login');
+    navigate(PATH_NAME.LOGIN);
   };
-
-  const loginInfo = useLoginInfoStore((state) => state.loginInfo);
 
   return (
     <>


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
- 헤더 프로필 버튼 클릭 핸들러 변경
- 헤더 프로필 이미지 변경

## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 헤더의 프로필 버튼 클릭 시 프로필 페이지로 가게 변경](https://github.com/Java-and-Script/pickple-front/commit/8286b0f120c627a0dc682062210ba84c3094c346)
[feat: 헤더 프로필 이미지 url 추가](https://github.com/Java-and-Script/pickple-front/commit/f7f4d33c3a88468a98635ec9a49158e6fa5328c4)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
![스크린샷 2023-11-13 오후 6 20 22](https://github.com/Java-and-Script/pickple-front/assets/81508534/d423b4ad-2e14-40b0-8f60-870daabeb805)

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
