### PR TITLE
ErrorPage 에 헤더, 하단Nav바 추가 및 FallbackPage구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,9 @@ import { router } from '@routes/router';
 import GlobalStyle from '@styles/globalStyle';
 import { theme } from '@styles/theme';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
 
 function App() {
   return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -29,37 +29,44 @@ type HeaderProps = {
   isLogo: boolean;
   title: string;
   isRightContainer: boolean;
+  onNavigate?: VoidFunction;
 };
 
 export const Header = ({
   isLogo = false,
   title = '',
   isRightContainer = true,
+  onNavigate,
 }: Partial<HeaderProps>) => {
   const navigate = useNavigate();
 
+  const handleClick = (callback: VoidFunction) => {
+    onNavigate?.();
+    callback();
+  };
+
   const handleLogoClick = () => {
-    navigate('/');
+    handleClick(() => navigate('/'));
   };
 
   const handleBackwardIconClick = () => {
-    navigate(-1);
+    handleClick(() => navigate(-1));
   };
 
   const handleSearchIconClick = () => {
-    navigate('/search');
+    handleClick(() => navigate('/search'));
   };
 
   const handleBellIconClick = () => {
-    navigate('/notification');
+    handleClick(() => navigate('/notification'));
   };
 
   const handleProfileIconClick = () => {
-    navigate('/all-services');
+    handleClick(() => navigate('/all-services'));
   };
 
   const handleLoginClick = () => {
-    navigate('/login');
+    handleClick(() => navigate('/login'));
   };
 
   const loginInfo = useLoginInfoStore((state) => state.loginInfo);

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -8,11 +8,12 @@ import plusIcon from '@/assets/plus.svg';
 
 import { NavbarButton, NavbarContainer } from './Navbar.style';
 
-export const Navbar = () => {
+export const Navbar = ({ onNavigate }: { onNavigate?: VoidFunction }) => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
   const handleNavbarClick = (page: string) => {
+    onNavigate?.();
     navigate(`/${page}`);
   };
 

--- a/src/hooks/useHeaderTitle.ts
+++ b/src/hooks/useHeaderTitle.ts
@@ -2,7 +2,7 @@ import { useIntersectionObserver } from './useIntersectionObserver';
 
 export const useHeaderTitle = <T extends HTMLElement>() => {
   const [entryRef, entry] = useIntersectionObserver<T>({});
-  const showHeaderTitle = !entry?.isIntersecting;
+  const showHeaderTitle = entry && !entry.isIntersecting;
 
   return { entryRef, showHeaderTitle };
 };

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -2,6 +2,8 @@ import { useNavigate } from 'react-router-dom';
 
 import { useQueryClient } from '@tanstack/react-query';
 
+import { Header } from '@components/Header';
+import { Navbar } from '@components/Navbar';
 import { Button } from '@components/shared/Button';
 import { Text } from '@components/shared/Text';
 
@@ -29,11 +31,9 @@ const buttonProps = {
   borderColor: theme.PALETTE.GRAY_400,
 } as const;
 
-export const ErrorPage = ({ error, resetErrorBoundary }: FallbackProps) => {
+export const ErrorPage = ({ resetErrorBoundary }: FallbackProps) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-
-  console.log(error);
 
   const reset = () => {
     resetErrorBoundary();
@@ -41,28 +41,37 @@ export const ErrorPage = ({ error, resetErrorBoundary }: FallbackProps) => {
   };
 
   return (
-    <PageWrapper>
-      <PageContent direction="column" gap={20} align="center" justify="start">
-        <LogoImage src={LOGO_SRC} width="35%" height="auto" alt="pickle logo" />
-        <div>
-          <Text size={40}>예상치 못한 오류가</Text>
-          <Text size={40}>발생했습니다.</Text>
-        </div>
-        <ButtonContainer gap={16}>
-          <Button {...buttonProps} onClick={reset}>
-            페이지 다시 로드
-          </Button>
-          <Button
-            {...buttonProps}
-            onClick={() => {
-              reset();
-              navigate(PATH_NAME.MAIN);
-            }}
-          >
-            홈페이지로
-          </Button>
-        </ButtonContainer>
-      </PageContent>
-    </PageWrapper>
+    <>
+      <PageWrapper>
+        <Header onNavigate={reset} />
+        <PageContent direction="column" gap={20} align="center" justify="start">
+          <LogoImage
+            src={LOGO_SRC}
+            width="35%"
+            height="auto"
+            alt="pickle logo"
+          />
+          <div>
+            <Text size={40}>예상치 못한 오류가</Text>
+            <Text size={40}>발생했습니다.</Text>
+          </div>
+          <ButtonContainer gap={16}>
+            <Button {...buttonProps} onClick={reset}>
+              페이지 다시 로드
+            </Button>
+            <Button
+              {...buttonProps}
+              onClick={() => {
+                reset();
+                navigate(PATH_NAME.MAIN);
+              }}
+            >
+              홈페이지로
+            </Button>
+          </ButtonContainer>
+        </PageContent>
+      </PageWrapper>
+      <Navbar onNavigate={reset} />
+    </>
   );
 };

--- a/src/pages/FallbackPage/FallbackPage.styles.ts
+++ b/src/pages/FallbackPage/FallbackPage.styles.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const PageWrapper = styled.div`
+  ${({ theme }) => theme.STYLES.LAYOUT}
+  height: 100dvh;
+`;

--- a/src/pages/FallbackPage/FallbackPage.tsx
+++ b/src/pages/FallbackPage/FallbackPage.tsx
@@ -1,0 +1,11 @@
+import { Header } from '@components/Header';
+
+import { PageWrapper } from './FallbackPage.styles';
+
+export const FallbackPage = () => {
+  return (
+    <PageWrapper>
+      <Header isLogo />
+    </PageWrapper>
+  );
+};

--- a/src/pages/FallbackPage/FallbackPage.tsx
+++ b/src/pages/FallbackPage/FallbackPage.tsx
@@ -1,11 +1,5 @@
-import { Header } from '@components/Header';
-
 import { PageWrapper } from './FallbackPage.styles';
 
 export const FallbackPage = () => {
-  return (
-    <PageWrapper>
-      <Header isLogo />
-    </PageWrapper>
-  );
+  return <PageWrapper />;
 };

--- a/src/pages/FallbackPage/index.ts
+++ b/src/pages/FallbackPage/index.ts
@@ -1,0 +1,1 @@
+export * from './FallbackPage';

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,14 +1,19 @@
+import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import styled from '@emotion/styled';
 
 import { Navbar } from '@components/Navbar/Navbar';
 
+import { FallbackPage } from './FallbackPage';
+
 export const Layout = () => {
   return (
     <>
       <LayoutWrapper>
-        <Outlet />
+        <Suspense fallback={<FallbackPage />}>
+          <Outlet />
+        </Suspense>
       </LayoutWrapper>
       <Navbar />
     </>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { createBrowserRouter } from 'react-router-dom';
 
@@ -36,11 +35,7 @@ export const router = createBrowserRouter([
     children: [
       {
         path: '',
-        element: (
-          <Suspense fallback={null}>
-            <MainPage />
-          </Suspense>
-        ),
+        element: <MainPage />,
       },
       { path: 'login', element: <LoginPage /> },
       { path: 'register', element: <RegisterPage /> },
@@ -48,91 +43,47 @@ export const router = createBrowserRouter([
       { path: 'players/:id', element: <h1>players</h1> },
       {
         path: 'games/near',
-        element: (
-          <Suspense>
-            <GamesNearPage />
-          </Suspense>
-        ),
+        element: <GamesNearPage />,
       },
       {
         path: 'games/host',
-        element: (
-          <Suspense fallback={null}>
-            <GamesHostPage />
-          </Suspense>
-        ),
+        element: <GamesHostPage />,
       },
       {
         path: 'games/participate',
-        element: (
-          <Suspense fallback={null}>
-            <GamesParticipatePage />
-          </Suspense>
-        ),
+        element: <GamesParticipatePage />,
       },
       {
         path: 'games/:id',
-        element: (
-          <Suspense fallback={null}>
-            <GamesDetailPage />
-          </Suspense>
-        ),
+        element: <GamesDetailPage />,
       },
       {
         path: 'games/:id/manage',
-        element: (
-          <Suspense fallback={null}>
-            <GamesManageParticipatePage />
-          </Suspense>
-        ),
+        element: <GamesManageParticipatePage />,
       },
       {
         path: 'games/:id/review',
-        element: (
-          <Suspense fallback={null}>
-            <MannerScoreReviewPage />
-          </Suspense>
-        ),
+        element: <MannerScoreReviewPage />,
       },
       {
         path: 'crews/recommend',
-        element: (
-          <Suspense fallback={null}>
-            <CrewsRecommendPage />
-          </Suspense>
-        ),
+        element: <CrewsRecommendPage />,
       },
       {
         path: 'crews/chief',
-        element: (
-          <Suspense fallback={null}>
-            <CrewsChiefPage />
-          </Suspense>
-        ),
+        element: <CrewsChiefPage />,
       },
       {
         path: 'crews/participate',
-        element: (
-          <Suspense fallback={null}>
-            <CrewsParticipatePage />
-          </Suspense>
-        ),
+        element: <CrewsParticipatePage />,
       },
       {
         path: 'crews/:id',
-        element: (
-          <Suspense fallback={null}>
-            <CrewsDetailPage />
-          </Suspense>
-        ),
+        element: <CrewsDetailPage />,
       },
       {
         path: 'crews/:id/manage',
-        element: (
-          <Suspense fallback={null}>
-            <CrewsManageParticipatePage />
-          </Suspense>
-        ),
+        element: <CrewsManageParticipatePage />,
       },
       {
         path: 'create',
@@ -140,27 +91,15 @@ export const router = createBrowserRouter([
       },
       {
         path: 'create/game',
-        element: (
-          <Suspense fallback={null}>
-            <CreateGamePage />
-          </Suspense>
-        ),
+        element: <CreateGamePage />,
       },
       {
         path: 'create/crew',
-        element: (
-          <Suspense fallback={null}>
-            <CreateCrewPage />
-          </Suspense>
-        ),
+        element: <CreateCrewPage />,
       },
       {
         path: 'profile/:id',
-        element: (
-          <Suspense fallback={null}>
-            <ProfilePage />
-          </Suspense>
-        ),
+        element: <ProfilePage />,
       },
       { path: 'profile/update', element: <h1>프로필 수정 페이지</h1> },
       {


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
- ErrorPage 에 헤더, 하단Nav바 추가
- FallbackPage구현

## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: 헤더, 하단Nav바에 onNavigate props 추가](https://github.com/Java-and-Script/pickple-front/commit/aa9adae01fa985c0b58ecc8ff3e8ad69e06315f0)
[feat: queryClient default option 추가](https://github.com/Java-and-Script/pickple-front/commit/c7e79e5aa15ceed1df512514e5850dc34c7af3cd)
[feat: ErrorPage 에 헤더, 하단Nav바 추가](https://github.com/Java-and-Script/pickple-front/commit/38fa273a5bb77577f2b2e803c88ff3f9178f3fbc)
[fix: useHeaderTitle 훅 수정](https://github.com/Java-and-Script/pickple-front/commit/8fb70a3c0b336f59e7f0547af7ec29072238c2b9) 
[feat: FallbackPage 추가](https://github.com/Java-and-Script/pickple-front/commit/e75bf98274260c1ea148b6470c1600909e0248d5)
[refactor: 최상위에 Suspense 하나만 두게 변경](https://github.com/Java-and-Script/pickple-front/commit/323c35d6df34e8c6b6376d356c86e35744009657) 
[fix: FallbackPage 헤더 제거](https://github.com/Java-and-Script/pickple-front/commit/a92b1660ad1fee09edfc406871f6c073d9950b14)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항
앞으로 페이지 구현해서 router에 적용 시 Suspense로 묶지 않아도 됩니다.
Layout.tsx 안에 Outlet을 Suspense로 묶어두었습니다.

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
