### PR TITLE
useMainPageNearGamesQuery 수정

### DIFF
--- a/src/pages/MainPage/useMainPageNearGamesQuery.ts
+++ b/src/pages/MainPage/useMainPageNearGamesQuery.ts
@@ -13,6 +13,6 @@ export const useMainPageNearGamesQuery = ({
 }) => {
   return useSuspenseQuery({
     queryKey: ['mainpage-games', category, value],
-    queryFn: () => getGames({ category, value, page: 1, size: FETCH_SIZE }),
+    queryFn: () => getGames({ category, value, page: 0, size: FETCH_SIZE }),
   });
 };


### PR DESCRIPTION
- page param을 0으로 변경

## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
메인페이지의 내 주변 경기 api 버그(첫 페이지가 불려오지 않음)

## 👨‍💻 구현 내용 or 👍 해결 내용
넘겨주는 page param 값을 0으로 변경해 해결

[fix: 메인 페이지의 주변 경기 불러오는 쿼리 수정](https://github.com/Java-and-Script/pickple-front/commit/ccc7a5c0114f63b3fe49ed4785ab4e0e7c529caf)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
