### PR TITLE
resetErrorBoundary 로직 버그 수정

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -29,44 +29,37 @@ type HeaderProps = {
   isLogo: boolean;
   title: string;
   isRightContainer: boolean;
-  onNavigate?: VoidFunction;
 };
 
 export const Header = ({
   isLogo = false,
   title = '',
   isRightContainer = true,
-  onNavigate,
 }: Partial<HeaderProps>) => {
   const navigate = useNavigate();
 
-  const handleClick = (callback: VoidFunction) => {
-    onNavigate?.();
-    callback();
-  };
-
   const handleLogoClick = () => {
-    handleClick(() => navigate('/'));
+    navigate('/');
   };
 
   const handleBackwardIconClick = () => {
-    handleClick(() => navigate(-1));
+    navigate(-1);
   };
 
   const handleSearchIconClick = () => {
-    handleClick(() => navigate('/search'));
+    navigate('/search');
   };
 
   const handleBellIconClick = () => {
-    handleClick(() => navigate('/notification'));
+    navigate('/notification');
   };
 
   const handleProfileIconClick = () => {
-    handleClick(() => navigate('/all-services'));
+    navigate('/all-services');
   };
 
   const handleLoginClick = () => {
-    handleClick(() => navigate('/login'));
+    navigate('/login');
   };
 
   const loginInfo = useLoginInfoStore((state) => state.loginInfo);

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -8,12 +8,11 @@ import plusIcon from '@/assets/plus.svg';
 
 import { NavbarButton, NavbarContainer } from './Navbar.style';
 
-export const Navbar = ({ onNavigate }: { onNavigate?: VoidFunction }) => {
+export const Navbar = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
   const handleNavbarClick = (page: string) => {
-    onNavigate?.();
     navigate(`/${page}`);
   };
 

--- a/src/hooks/usePathnameChange.ts
+++ b/src/hooks/usePathnameChange.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const usePathnameChange = (onChange: VoidFunction) => {
+  const location = useLocation();
+  const initialPathname = useRef(location);
+
+  useEffect(() => {
+    if (initialPathname.current !== location) {
+      onChange();
+    }
+  }, [location, onChange]);
+};

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useQueryClient } from '@tanstack/react-query';
@@ -6,6 +7,8 @@ import { Header } from '@components/Header';
 import { Navbar } from '@components/Navbar';
 import { Button } from '@components/shared/Button';
 import { Text } from '@components/shared/Text';
+
+import { usePathnameChange } from '@hooks/usePathnameChange';
 
 import { theme } from '@styles/theme';
 
@@ -35,15 +38,17 @@ export const ErrorPage = ({ resetErrorBoundary }: FallbackProps) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const reset = () => {
+  const reset = useCallback(() => {
     resetErrorBoundary();
     queryClient.clear();
-  };
+  }, [queryClient, resetErrorBoundary]);
+
+  usePathnameChange(reset);
 
   return (
     <>
       <PageWrapper>
-        <Header onNavigate={reset} />
+        <Header />
         <PageContent direction="column" gap={20} align="center" justify="start">
           <LogoImage
             src={LOGO_SRC}
@@ -59,19 +64,13 @@ export const ErrorPage = ({ resetErrorBoundary }: FallbackProps) => {
             <Button {...buttonProps} onClick={reset}>
               페이지 다시 로드
             </Button>
-            <Button
-              {...buttonProps}
-              onClick={() => {
-                reset();
-                navigate(PATH_NAME.MAIN);
-              }}
-            >
+            <Button {...buttonProps} onClick={() => navigate(PATH_NAME.MAIN)}>
               홈페이지로
             </Button>
           </ButtonContainer>
         </PageContent>
       </PageWrapper>
-      <Navbar onNavigate={reset} />
+      <Navbar />
     </>
   );
 };


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
resetErrorBoundary 로직 버그 수정
문제상황
- navigate(-1) 과 resetErrorBoundary 를 같이 실행할 시 에러바운더리 리셋이 되지 않는 문제

## 👨‍💻 구현 내용 or 👍 해결 내용
1. location이 변경되었음을 감지하고 callback을 실행하는  커스텀 훅 제작
2. 만들어진 커스텀 훅에 resetErrorBoundary 전달

[fix: Header, Navbar 컴포넌트 롤백](https://github.com/Java-and-Script/pickple-front/commit/94f5de0de90430348b85fe1cbfb2f232141a7ded)
[feat: url 변경 시 resetErrorBoundary 실행하는 기능 추가](https://github.com/Java-and-Script/pickple-front/commit/b231869b6b9f798349323616af4540fa420a243b)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
