### PR TITLE
Skeleton 컴포넌트 구현

### DIFF
--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,18 @@
+import { SkeletonContext } from './SkeletonContext';
+import { SkeletonItem, SkeletonItemProps } from './SkeletonItem';
+
+type SkeletonProps = {
+  children: React.ReactNode;
+} & Required<SkeletonItemProps>;
+
+const Skeleton = ({ children, ...skeletonProviderProps }: SkeletonProps) => {
+  return (
+    <SkeletonContext.Provider value={skeletonProviderProps}>
+      {children}
+    </SkeletonContext.Provider>
+  );
+};
+
+Skeleton.Item = SkeletonItem;
+
+export { Skeleton };

--- a/src/components/Skeleton/SkeletonContext.ts
+++ b/src/components/Skeleton/SkeletonContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+import { SkeletonItemProps } from './SkeletonItem';
+
+export const SkeletonContext =
+  createContext<Required<SkeletonItemProps> | null>(null);

--- a/src/components/Skeleton/SkeletonItem/SkeletonItem.styles.ts
+++ b/src/components/Skeleton/SkeletonItem/SkeletonItem.styles.ts
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { SkeletonItemProps } from '.';
+import { generateSkeletonKeyframes } from './generateSkeletonKeyframes';
+
+export const SkeletonAnimatedDiv = styled.div<Required<SkeletonItemProps>>`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  border-radius: ${({ radius }) => radius};
+
+  -webkit-animation: ${({ defaultColor, gradientColor }) => css`
+    ${generateSkeletonKeyframes(
+      defaultColor,
+      gradientColor
+    )} 1.8s infinite ease-in-out
+  `};
+
+  animation: ${({ defaultColor, gradientColor }) => css`
+    ${generateSkeletonKeyframes(defaultColor, gradientColor)}
+    1.8s infinite ease-in-out
+  `};
+`;

--- a/src/components/Skeleton/SkeletonItem/SkeletonItem.tsx
+++ b/src/components/Skeleton/SkeletonItem/SkeletonItem.tsx
@@ -1,0 +1,30 @@
+import { useSkeletonContext } from '../useSkeletonContext';
+import { SkeletonAnimatedDiv } from './SkeletonItem.styles';
+
+export type SkeletonItemProps = {
+  width?: string;
+  height?: string;
+  radius?: string;
+  defaultColor?: string;
+  gradientColor?: string;
+};
+
+export const SkeletonItem = ({
+  width,
+  height,
+  radius,
+  defaultColor,
+  gradientColor,
+}: SkeletonItemProps) => {
+  const context = useSkeletonContext();
+
+  return (
+    <SkeletonAnimatedDiv
+      width={width ?? context.width}
+      height={height ?? context.height}
+      radius={radius ?? context.radius}
+      defaultColor={defaultColor ?? context.defaultColor}
+      gradientColor={gradientColor ?? context.gradientColor}
+    />
+  );
+};

--- a/src/components/Skeleton/SkeletonItem/generateSkeletonKeyframes.ts
+++ b/src/components/Skeleton/SkeletonItem/generateSkeletonKeyframes.ts
@@ -1,0 +1,20 @@
+import { keyframes } from '@emotion/react';
+
+export const generateSkeletonKeyframes = (
+  defaultColor: string,
+  gradientColor: string
+) => {
+  return keyframes`
+    0% {
+      background-color: ${defaultColor};
+    }
+
+    50% {
+      background-color: ${gradientColor};
+    }
+
+    100% {
+      background-color: ${defaultColor};
+    }
+    `;
+};

--- a/src/components/Skeleton/SkeletonItem/index.ts
+++ b/src/components/Skeleton/SkeletonItem/index.ts
@@ -1,0 +1,1 @@
+export * from './SkeletonItem';

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export * from './Skeleton';

--- a/src/components/Skeleton/useSkeletonContext.ts
+++ b/src/components/Skeleton/useSkeletonContext.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+
+import { SkeletonContext } from './SkeletonContext';
+
+export const useSkeletonContext = () => {
+  const context = useContext(SkeletonContext);
+  if (!context) {
+    throw new Error(
+      '"useSkeletonContext"는 "SkeletonProvider"와 같이 쓰여야 합니다.'
+    );
+  }
+
+  return context;
+};

--- a/src/components/shared/Flex/Flex.ts
+++ b/src/components/shared/Flex/Flex.ts
@@ -8,11 +8,13 @@ type FlexProps = {
   align?: CSSProperties['alignItems'];
   direction?: CSSProperties['flexDirection'];
   flexWrap?: CSSProperties['flexWrap'];
+  grow?: boolean;
 };
 
 export const Flex = styled.div<FlexProps>`
   display: flex;
   gap: ${({ gap }) => gap}px;
+  flex-grow: ${({ grow }) => (grow ? '1' : undefined)};
   flex-direction: ${({ direction }) => direction || 'row'};
   align-items: ${({ align }) => align || 'first'};
   justify-content: ${({ justify }) => justify || 'first'};


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
SkeletonContext 구현
useSkeletonContext 훅 구현
Skeleton 컴포넌트 구현

## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: Flex 컴포넌트 flex-grow 설정 기능](https://github.com/Java-and-Script/pickple-front/commit/4a8fcba86f34eefec528bab9f11fa04c35744007)
[feat: 스켈레톤 애니메이션 keyframe 만드는 함수 구현](https://github.com/Java-and-Script/pickple-front/commit/2513c5043bbc7950050109b6e83545752b3fb649)
[feat: Skeleton 컴포넌트 구현](https://github.com/Java-and-Script/pickple-front/commit/1bfa71ab0ba652c967505cc8b0044cd979e1dbb2)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

https://github.com/Java-and-Script/pickple-front/assets/81508534/5a2c511c-80f4-4f80-80e5-550d84ae8d5b

```tsx
        <Skeleton
          width="100%"
          height="30px"
          radius="5px"
          defaultColor={theme.PALETTE.GRAY_300}
          gradientColor={theme.PALETTE.GRAY_200}
        >
          <Skeleton.Item height="200px" />
          <Flex gap={5}>
            <Skeleton.Item width="100px" height="100px" radius="50%" />
            <Flex direction="column" grow gap={5}>
              <Skeleton.Item />
              <Skeleton.Item />
              <Skeleton.Item width="200px" />
            </Flex>
          </Flex>
        </Skeleton>
```

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트
Skeleton 컴포넌트로 Provider를 만들고 Skeleton.Item을 사용해 요소를 만듭니다.
Skeleton 컴포넌트에 default값을 넘겨야하며 Item에서 다시 정의하여 사용할 수 있습니다.
Skeleton.Item은 단독으로 사용할 수 없습니다.
<!--리뷰어가 집중했으면 하는 부분 -->


## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
