### PR TITLE
chat api 변경 내역 반영 및 비로그인 시 프로필 페이지 접근 불가 버그 수정

### DIFF
--- a/src/hooks/useChatOnButtonClick.ts
+++ b/src/hooks/useChatOnButtonClick.ts
@@ -1,0 +1,125 @@
+import { useQuery } from '@tanstack/react-query';
+import SockJS from 'sockjs-client';
+import Stomp from 'stompjs';
+
+import { getAllChatRoomList } from '@api/chat/getAllChatRoomList';
+import { getPersonalChatRoomExisted } from '@api/chat/getPersonalChatRoomExisted';
+
+import {
+  connect,
+  enter,
+  stompConfig,
+  subscribe,
+} from '@pages/ChattingPage/stompApi';
+
+import { useCreatePersonalChatRoomMutation } from '@hooks/mutations/useCreatePersonalChatRoomMutation';
+
+import { SendMessageRequest } from '@type/api/chat';
+import { Member } from '@type/models';
+import { ChatMessage } from '@type/models/ChatMessage';
+import { ChatRoom } from '@type/models/ChatRoom';
+
+import { CHAT_ROOM_TAB_TITLE } from '@consts/chatRoomTabTitle';
+import { PATH_NAME } from '@consts/pathName';
+
+type useChatOnButtonClickProps = {
+  targetId: Member['id'];
+  targetNickname: Member['nickname'];
+  myId: Member['id'] | null;
+  navigate: (path: string) => void;
+};
+
+export const useChatOnButtonClick = ({
+  targetId,
+  targetNickname,
+  myId = null,
+  navigate: moveToPage,
+}: useChatOnButtonClickProps) => {
+  const { refetch: fetchPersonalChatRoomExisted } = useQuery({
+    queryKey: ['personal-room-existed', targetId],
+    queryFn: () => getPersonalChatRoomExisted({ receiverId: targetId }),
+    enabled: false,
+  });
+
+  const { refetch: fetchAllChatRoomList } = useQuery({
+    queryKey: ['all-chat-room-list', CHAT_ROOM_TAB_TITLE.INDIVIDUAL],
+    queryFn: () => getAllChatRoomList({ type: CHAT_ROOM_TAB_TITLE.INDIVIDUAL }),
+    enabled: false,
+  });
+
+  const { mutateAsync } = useCreatePersonalChatRoomMutation();
+
+  const handleExistingRoom = async (
+    individualRooms: ChatRoom[],
+    isSenderActive: boolean
+  ) => {
+    const { id: roomId } =
+      individualRooms.find(
+        ({ roomName }: { roomName: string }) => roomName === targetNickname
+      ) || {};
+    if (!roomId) {
+      return;
+    }
+
+    if (isSenderActive) {
+      moveToPage(PATH_NAME.GET_CHAT_PATH(String(roomId)));
+    } else {
+      const sock = new SockJS(stompConfig.webSocketEndpoint);
+      const stompClient = Stomp.over(sock);
+
+      connect({
+        stompClient,
+        connectEvent: () => {
+          subscribe({
+            stompClient,
+            roomId,
+            subscribeEvent: (received: ChatMessage) => {
+              const {
+                type,
+                sender: { id: senderId },
+              } = received;
+
+              if (type === '입장' && senderId === myId) {
+                moveToPage(PATH_NAME.GET_CHAT_PATH(String(received.roomId)));
+                sock.close();
+              }
+            },
+          });
+
+          const sendData: SendMessageRequest = {
+            senderId: myId!,
+            content: null,
+          };
+
+          enter({ stompClient, roomId, sendData });
+        },
+      });
+    }
+  };
+
+  const handleClickChattingButton = async () => {
+    if (!myId) {
+      moveToPage(PATH_NAME.LOGIN);
+      return;
+    }
+
+    const { data } = await fetchPersonalChatRoomExisted();
+    if (!data) return;
+
+    const { isRoomExisted, isSenderActive } = data;
+
+    if (isRoomExisted) {
+      const { data: individualRooms } = await fetchAllChatRoomList();
+      if (individualRooms) {
+        handleExistingRoom(individualRooms, isSenderActive);
+      }
+    } else {
+      const { id: roomId } = await mutateAsync({
+        receiverId: targetId,
+      });
+      moveToPage(PATH_NAME.GET_CHAT_PATH(String(roomId)));
+    }
+  };
+
+  return { handleClickChattingButton };
+};

--- a/src/pages/ChatRoomListPage/ChatRoomListPage.style.ts
+++ b/src/pages/ChatRoomListPage/ChatRoomListPage.style.ts
@@ -30,6 +30,7 @@ export const TabBarButton = styled.button<{ isSelected: boolean }>`
   border-bottom: ${({ isSelected }) =>
     isSelected ? ' 1px solid black' : ' 1px solid white'};
   padding: 10px;
+  color: black;
 `;
 
 export const ChatItemAvatar = styled(Image)`

--- a/src/pages/ChatRoomListPage/useChatRoomListPage.ts
+++ b/src/pages/ChatRoomListPage/useChatRoomListPage.ts
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAllChatRoomListQuery } from '@hooks/queries/useAllChatRoomListQuery.ts';
 
 import { useChatRoomTabStore } from '@stores/chatRoomTab.store';
+import { useLoginInfoStore } from '@stores/loginInfo.store';
 
 import { ChatRoom } from '@type/models/ChatRoom.ts';
 
@@ -11,6 +12,11 @@ import { CHAT_ROOM_TAB_TITLE } from '@consts/chatRoomTabTitle.ts';
 
 export const useChatRoomListPage = () => {
   const navigate = useNavigate();
+
+  const loginInfo = useLoginInfoStore((state) => state.loginInfo);
+  if (!loginInfo?.id) {
+    throw new Error('로그인이 필요한 서비스입니다.');
+  }
 
   const { data: individualRooms } = useAllChatRoomListQuery({
     type: CHAT_ROOM_TAB_TITLE.INDIVIDUAL,

--- a/src/pages/ChattingPage/stompApi.ts
+++ b/src/pages/ChattingPage/stompApi.ts
@@ -57,6 +57,10 @@ export const subscribe = <T>({
   });
 };
 
+export const enter = <T>({ stompClient, roomId, sendData }: LeaveProps<T>) => {
+  stompClient.send(stompConfig.enter(roomId), {}, JSON.stringify(sendData));
+};
+
 export const send = <T>({ stompClient, roomId, sendData }: SendProps<T>) => {
   stompClient.send(stompConfig.send(roomId), {}, JSON.stringify(sendData));
 };

--- a/src/pages/ProfilePage/Profile.tsx
+++ b/src/pages/ProfilePage/Profile.tsx
@@ -78,7 +78,7 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
   };
 
   const handleClickChattingButton = async () => {
-    if (!isChatExisted?.existed) {
+    if (!isChatExisted?.isRoomExisted) {
       const { id: roomId } = await mutateAsync({ receiverId: memberId });
 
       moveToPage(PATH_NAME.GET_CHAT_PATH(String(roomId)));

--- a/src/pages/ProfilePage/Profile.tsx
+++ b/src/pages/ProfilePage/Profile.tsx
@@ -7,10 +7,8 @@ import { Flex } from '@components/shared/Flex';
 import { Image } from '@components/shared/Image';
 import { Text } from '@components/shared/Text';
 
-import { useCreatePersonalChatRoomMutation } from '@hooks/mutations/useCreatePersonalChatRoomMutation';
-import { useAllChatRoomListQuery } from '@hooks/queries/useAllChatRoomListQuery';
 import { useMemberProfileQuery } from '@hooks/queries/useMemberProfileQuery';
-import { usePersonalChatRoomExistedQuery } from '@hooks/queries/usePersonalChatRoomExistedQuery';
+import { useChatOnButtonClick } from '@hooks/useChatOnButtonClick';
 
 import { theme } from '@styles/theme';
 
@@ -18,7 +16,6 @@ import { useLoginInfoStore } from '@stores/loginInfo.store';
 
 import { Member } from '@type/models';
 
-import { CHAT_ROOM_TAB_TITLE } from '@consts/chatRoomTabTitle';
 import { PATH_NAME } from '@consts/pathName';
 
 import Social from '@assets/follow.svg?react';
@@ -55,17 +52,10 @@ type NumberedItemProps = {
 };
 
 export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
-  const myId = useLoginInfoStore((state) => state.loginInfo?.id);
+  const myId = useLoginInfoStore((state) => state.loginInfo?.id) ?? null;
   const navigate = useNavigate();
 
-  const { data: profileData } = useMemberProfileQuery({ memberId });
-  const { data: isChatExisted } = usePersonalChatRoomExistedQuery({
-    receiverId: memberId,
-  });
-  const { data: individualRooms } = useAllChatRoomListQuery({
-    type: CHAT_ROOM_TAB_TITLE.INDIVIDUAL,
-  });
-  const { mutateAsync } = useCreatePersonalChatRoomMutation();
+  const { data: profile } = useMemberProfileQuery({ memberId });
 
   const [isHeartClicked, setIsHeartClicked] = useState(false);
 
@@ -77,34 +67,27 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
     navigate(path);
   };
 
-  const handleClickChattingButton = async () => {
-    if (!isChatExisted?.isRoomExisted) {
-      const { id: roomId } = await mutateAsync({ receiverId: memberId });
-
-      moveToPage(PATH_NAME.GET_CHAT_PATH(String(roomId)));
-    } else {
-      const { id: roomId } = individualRooms.find(
-        ({ roomName }) => roomName === profileData.nickname
-      )!;
-
-      moveToPage(PATH_NAME.GET_CHAT_PATH(String(roomId)));
-    }
-  };
+  const { handleClickChattingButton } = useChatOnButtonClick({
+    targetId: memberId,
+    targetNickname: profile.nickname,
+    navigate,
+    myId,
+  });
 
   return (
     <Main>
       <FlexItem>
         <Flex align="flex-end" gap={8}>
           <Text size={24} lineHeight="">
-            {profileData.nickname}
+            {profile.nickname}
           </Text>
           <Text size={12}>
-            {profileData.addressDepth1 + ' ' + profileData.addressDepth2}
+            {profile.addressDepth1 + ' ' + profile.addressDepth2}
           </Text>
         </Flex>
         <Flex justify="center" gap={40} align="center">
           <Avatar
-            src={profileData.profileImageUrl}
+            src={profile.profileImageUrl}
             size={100}
             border={`1px solid ${theme.PALETTE.GRAY_400}`}
           />
@@ -115,13 +98,13 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
             <NumberedItem
               text="매너스코어"
               icon={<Heart />}
-              count={profileData.mannerScore}
+              count={profile.mannerScore}
               color="pink"
             />
             <NumberedItem
               text="평가한 사람"
               icon={<HandHeart />}
-              count={profileData.mannerScoreCount}
+              count={profile.mannerScoreCount}
               color="black"
             />
           </NumberedItemWrapper>
@@ -140,16 +123,16 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
           </Flex>
         )}
         <ProfileField category="포지션">
-          {profileData.positions.length
-            ? profileData.positions.map((position) => (
+          {profile.positions.length
+            ? profile.positions.map((position) => (
                 <ItemBox key={position}>{position}</ItemBox>
               ))
             : '없음'}
         </ProfileField>
         <ProfileField category="소속 크루">
           <CrewGroup>
-            {profileData.crews.length
-              ? profileData.crews.map((crew) => (
+            {profile.crews.length
+              ? profile.crews.map((crew) => (
                   <ItemBox border="none" key={crew.id}>
                     <Image
                       src={crew.profileImageUrl}
@@ -164,7 +147,7 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
         <ProfileField category="획득한 뱃지">{'없음'}</ProfileField>
         <ProfileField category="자기소개">
           <Introduce>
-            <Text>{profileData.introduction}</Text>
+            <Text>{profile.introduction}</Text>
           </Introduce>
         </ProfileField>
       </FlexItem>

--- a/src/type/api/chat.ts
+++ b/src/type/api/chat.ts
@@ -11,7 +11,10 @@ export type GetPersonalChatRoomExistedRequest = {
   receiverId: number;
 };
 
-export type GetPersonalChatRoomExistedResponse = { existed: boolean };
+export type GetPersonalChatRoomExistedResponse = {
+  isRoomExisted: boolean;
+  isSenderActive: boolean;
+};
 
 export type GetAllChatRoomListRequest = {
   type: ChatRoom['type'];


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
- 1:1 채팅방에서 나가기를 하면 대화를 했던 상대방 이름을 가져올 수 없는 문제가 발생해 채팅 목록 페이지에 접근할 때 에러가 발생했습니다.
  상대방 이름을 가져올 수 있도록 채팅방을 구성하는 멤버 이름은 유지하되, `isSenderActive`로 상대방이 채팅방에 실제로 속해있는지 판별하기로 했습니다.
- 비로그인 시 profile 페이지에 접근할 수 없는 문제도 함께 해결했습니다(대화걸기 버튼 이벤트를 훅으로 분리하면서 쿼리 수정).

## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: GetPersonalChatRoomExistedResponse 변경 내역 반영](https://github.com/Java-and-Script/pickple-front/commit/5a5c12ce2cea24b004de7ccd988679aa885b1493)
 
[feat: 채팅방 입장 api 추가](https://github.com/Java-and-Script/pickple-front/commit/b12edfce0f926d9b364de9d2074c3e664b3e6831)
 
[feat: 대화걸기 버튼 클릭 훅 작성](https://github.com/Java-and-Script/pickple-front/commit/b6292c5e044a04428b5aef8707e18b977ece5909)

[feat: 프로필 페이지 대화걸기 버튼 훅 적용](https://github.com/Java-and-Script/pickple-front/commit/b01a8558297626729a35fba89276e2629c2be06b)
 
[feat: 채팅 목록 페이지 로그인 validation 작성](https://github.com/Java-and-Script/pickple-front/commit/2ccbff6999faf7a733dd93cf53ed29d6803456a5)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항
게스트 모집 상세 페이지에서 아래 코드를 가져다 사용하시면 좋을 것 같습니다!
```tsx
  const { handleClickChattingButton } = useChatOnButtonClick({
    targetId: match.host.id,
    targetNickname: match.host.nickname,
    navigate,
    myId: loginInfo?.id ?? null,
  });
```
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
