### PR TITLE
프로필 페이지 내 포지션, 크루 클릭 이벤트 구현

### DIFF
--- a/src/pages/ProfilePage/Profile.tsx
+++ b/src/pages/ProfilePage/Profile.tsx
@@ -25,7 +25,7 @@ import Social from '@assets/follow.svg?react';
 import HandHeart from '@assets/handHeart.svg?react';
 import Heart from '@assets/heart.svg?react';
 
-import { ModalItem } from './ProfilePage.style';
+import { ModalItem, PointerFlex } from './ProfilePage.style';
 import {
   ColoredSvgWrapper,
   CrewGroup,
@@ -233,7 +233,7 @@ const EventButton = ({ text, width, onClick }: EventButtonProps) => (
 
 const NumberedItem = ({ text, count, icon, color }: NumberedItemProps) => {
   return (
-    <Flex direction="column" align="center" gap={4}>
+    <PointerFlex direction="column" align="center" gap={4}>
       <Text size={12} color={theme.PALETTE.GRAY_400}>
         {text}
       </Text>
@@ -241,6 +241,6 @@ const NumberedItem = ({ text, count, icon, color }: NumberedItemProps) => {
       <Text size={16} color={theme.PALETTE.GRAY_400}>
         {count}
       </Text>
-    </Flex>
+    </PointerFlex>
   );
 };

--- a/src/pages/ProfilePage/Profile.tsx
+++ b/src/pages/ProfilePage/Profile.tsx
@@ -58,7 +58,6 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
   const { data: profile } = useMemberProfileQuery({ memberId });
 
   const [isHeartClicked, setIsHeartClicked] = useState(false);
-
   const handleClickHeart = () => {
     setIsHeartClicked((prev: boolean) => !prev);
   };
@@ -73,6 +72,10 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
     navigate,
     myId,
   });
+
+  const handleClickCrew = (id: Member['id']) => {
+    moveToPage(PATH_NAME.GET_CREWS_PATH(String(id)));
+  };
 
   return (
     <Main>
@@ -133,7 +136,11 @@ export const Profile = ({ memberId }: { memberId: Member['id'] }) => {
           <CrewGroup>
             {profile.crews.length
               ? profile.crews.map((crew) => (
-                  <ItemBox border="none" key={crew.id}>
+                  <ItemBox
+                    border="none"
+                    key={crew.id}
+                    onClick={() => handleClickCrew(crew.id)}
+                  >
                     <Image
                       src={crew.profileImageUrl}
                       width="45"

--- a/src/pages/ProfilePage/ProfilePage.style.ts
+++ b/src/pages/ProfilePage/ProfilePage.style.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { Flex } from '@components/shared/Flex';
+
 const MAX_WIDTH = '480px';
 
 export const ProfileContainer = styled.div`
@@ -96,4 +98,8 @@ export const NumberedItemWrapper = styled.div<{ isClicked: boolean }>`
       transform: rotateY(0deg);
     }
   `}
+`;
+
+export const ModalItem = styled(Flex)`
+  margin: 16px;
 `;

--- a/src/pages/ProfilePage/ProfilePage.style.ts
+++ b/src/pages/ProfilePage/ProfilePage.style.ts
@@ -36,6 +36,7 @@ export const ItemBox = styled.div<{ border?: string }>`
   color: ${({ theme }) => theme.PALETTE.GRAY_400};
   font-size: ${({ theme }) => theme.FONT_SIZE.XS};
   overflow: hidden;
+  cursor: pointer;
 `;
 
 export const ProfileFieldContainer = styled.div`
@@ -60,6 +61,10 @@ export const Introduce = styled.div`
   & > p {
     white-space: pre-wrap;
   }
+`;
+
+export const PointerFlex = styled(Flex)`
+  cursor: pointer;
 `;
 
 export const ColoredSvgWrapper = styled.div<{ color?: string }>`


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
프로필 페이지의 크루 아바타와 포지션 뱃지에 대한 클릭 이벤트를 추가했습니다.
크루 아바타를 클릭하면 크루 상세 페이지로 이동하고, 포지션 뱃지를 클릭하면 포지션에 대한 설명이 모달로 뜹니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: 크루 아바타 클릭 이벤트 작성](https://github.com/Java-and-Script/pickple-front/commit/a20c5cfb7a325f8e9ad065c73af23056e52816a9)
 
[feat: 포지션 클릭 이벤트 작성](https://github.com/Java-and-Script/pickple-front/commit/42e7fa1e27a555a9320df565030eeff2b07ff2c3)

 [chore: 뱃지 커서 포인터 효과](https://github.com/Java-and-Script/pickple-front/commit/e8d8d3b970686c19ed94816e6f04fe5aa31fd72f)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
