### PR TITLE
채팅 목록 페이지 쿼리 수정

### DIFF
--- a/src/hooks/queries/useAllChatRoomListQuery.ts
+++ b/src/hooks/queries/useAllChatRoomListQuery.ts
@@ -11,5 +11,6 @@ export const useAllChatRoomListQuery = ({
     queryKey: ['all-chat-room-list', type],
     queryFn: () => getAllChatRoomList({ type }),
     refetchOnMount: 'always',
+    refetchInterval: 10000,
   });
 };

--- a/src/pages/ChatRoomListPage/ChatRoomListPage.tsx
+++ b/src/pages/ChatRoomListPage/ChatRoomListPage.tsx
@@ -3,6 +3,8 @@ import { Flex } from '@components/shared/Flex';
 
 import { theme } from '@styles/theme.ts';
 
+import { ChatRoom } from '@type/models/ChatRoom.ts';
+
 import { CHAT_ROOM_TAB_TITLE } from '@consts/chatRoomTabTitle.ts';
 import { PATH_NAME } from '@consts/pathName.ts';
 
@@ -17,7 +19,7 @@ import {
 import { useChatRoomListPage } from './useChatRoomListPage.ts';
 
 export const ChatRoomListPage = () => {
-  const { selectedData, chatRoomTab, moveToPage, handleClickTab } =
+  const { selectedTabChatRoomList, chatRoomTab, moveToPage, handleClickTab } =
     useChatRoomListPage();
 
   return (
@@ -35,13 +37,13 @@ export const ChatRoomListPage = () => {
             </TabBarButton>
           ))}
         </TabBar>
-        {selectedData.length !== 0 ? (
-          selectedData.map((messageItem, i) => (
+        {selectedTabChatRoomList.length !== 0 ? (
+          selectedTabChatRoomList.map((chatRoomItem: ChatRoom) => (
             <ChatRoomItem
-              chatRoomItem={messageItem}
-              key={i}
+              chatRoomItem={chatRoomItem}
+              key={chatRoomItem.id}
               onClickChatRoomItem={() =>
-                moveToPage(PATH_NAME.GET_CHAT_PATH(String(messageItem.id)))
+                moveToPage(PATH_NAME.GET_CHAT_PATH(String(chatRoomItem.id)))
               }
             />
           ))

--- a/src/pages/ChatRoomListPage/useChatRoomListPage.ts
+++ b/src/pages/ChatRoomListPage/useChatRoomListPage.ts
@@ -33,9 +33,19 @@ export const useChatRoomListPage = () => {
   };
 
   return {
-    selectedTabChatRoomList,
+    selectedTabChatRoomList: sortDate(selectedTabChatRoomList),
     chatRoomTab,
     moveToPage,
     handleClickTab,
   };
+};
+
+const sortDate = (chatRooms: ChatRoom[]) => {
+  chatRooms.sort(
+    (prev: ChatRoom, cur: ChatRoom) =>
+      new Date(cur.lastMessageCreatedAt).getTime() -
+      new Date(prev.lastMessageCreatedAt).getTime()
+  );
+
+  return chatRooms;
 };

--- a/src/pages/ChatRoomListPage/useChatRoomListPage.ts
+++ b/src/pages/ChatRoomListPage/useChatRoomListPage.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAllChatRoomListQuery } from '@hooks/queries/useAllChatRoomListQuery.ts';
@@ -8,8 +7,6 @@ import { useLoginInfoStore } from '@stores/loginInfo.store';
 
 import { ChatRoom } from '@type/models/ChatRoom.ts';
 
-import { CHAT_ROOM_TAB_TITLE } from '@consts/chatRoomTabTitle.ts';
-
 export const useChatRoomListPage = () => {
   const navigate = useNavigate();
 
@@ -18,19 +15,12 @@ export const useChatRoomListPage = () => {
     throw new Error('로그인이 필요한 서비스입니다.');
   }
 
-  const { data: individualRooms } = useAllChatRoomListQuery({
-    type: CHAT_ROOM_TAB_TITLE.INDIVIDUAL,
-  });
-  const { data: guestRooms } = useAllChatRoomListQuery({
-    type: CHAT_ROOM_TAB_TITLE.GUEST,
-  });
-  const { data: crewRooms } = useAllChatRoomListQuery({
-    type: CHAT_ROOM_TAB_TITLE.CREW,
-  });
-
   const { chatRoomTab, setChatRoomTab } = useChatRoomTabStore();
 
-  const [selectedData, setSelectedData] = useState(individualRooms);
+  const { data: selectedTabChatRoomList, refetch: refetchChatList } =
+    useAllChatRoomListQuery({
+      type: chatRoomTab,
+    });
 
   const moveToPage = (pathName: string) => {
     navigate(pathName);
@@ -38,17 +28,14 @@ export const useChatRoomListPage = () => {
 
   const handleClickTab = (tab: ChatRoom['type']) => {
     setChatRoomTab(tab);
+
+    refetchChatList();
   };
 
-  useEffect(() => {
-    if (chatRoomTab === CHAT_ROOM_TAB_TITLE.INDIVIDUAL) {
-      setSelectedData(individualRooms);
-    } else if (chatRoomTab === CHAT_ROOM_TAB_TITLE.GUEST) {
-      setSelectedData(guestRooms);
-    } else {
-      setSelectedData(crewRooms);
-    }
-  }, [individualRooms, guestRooms, crewRooms, chatRoomTab]);
-
-  return { selectedData, chatRoomTab, moveToPage, handleClickTab };
+  return {
+    selectedTabChatRoomList,
+    chatRoomTab,
+    moveToPage,
+    handleClickTab,
+  };
 };


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
채팅 목록 페이지에 접속했을 때 3개의 api를 동시에 불러오는 문제가 있어, 탭 별로 api를 호출할 수 있도록 로직을 수정했습니다.

또한, 채팅 목록을 지속적으로 업데이트 할 수 있도록 refetchInterval을 설정해두었습니다.(일단은 10초)

채팅 목록을 시간 순으로 정렬하는 코드도 추가했습니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 클릭된 탭의 채팅 목록만 fetch하도록 변경](https://github.com/Java-and-Script/pickple-front/commit/754ffc116ed378dc2bf258a735ef70a49a5b5489)
 
[fix: 채팅 목록 쿼리 refetchInterval 설정](https://github.com/Java-and-Script/pickple-front/commit/3208af500f81329b45ff832560a6fade3c92d1b0)
 
[chore: 변경된 변수명 적용 및 map 함수 key 변경](https://github.com/Java-and-Script/pickple-front/commit/54339f6dbb51f655b1456296fc39605f0fed6fc5)
 
[feat: 채팅방 목록 시간 순 정렬 구현](https://github.com/Java-and-Script/pickple-front/commit/80f7cbd7aa73d075c9a8a09f4cf855f4e57fb449)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
