### PR TITLE
페이지 이동 시 스크롤이 내려가 있는 버그

### DIFF
--- a/src/routes/ScrollTop.tsx
+++ b/src/routes/ScrollTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const ScrollTop = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, [location]);
+
+  return null;
+};

--- a/src/routes/ScrollTop.tsx
+++ b/src/routes/ScrollTop.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export const ScrollTop = () => {
   const location = useLocation();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     window.scrollTo({ top: 0 });
   }, [location]);
 

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -40,12 +40,15 @@ import { RegisterPage } from '@pages/RegisterPage';
 import { CardListPageSkeleton } from '@pages/__components__/CardListPageSkeleton';
 import { ManagePageSkeleton } from '@pages/__components__/ManagePageSkeleton';
 
+import { ScrollTop } from './ScrollTop';
+
 export const router = createBrowserRouter([
   {
     path: '/',
     element: (
       <ErrorBoundary FallbackComponent={ErrorPage}>
         <ErrorBoundary FallbackComponent={AuthErrorPage}>
+          <ScrollTop />
           <Layout />
         </ErrorBoundary>
       </ErrorBoundary>


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
페이지 이동 시 스크롤이 내려간 상태로 렌더링되는 버그
[관련된 노션](https://www.notion.so/prgrms/d2b5e0136b684f7c99833d7f1357004f?pvs=4)

## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: ScrollTop 컴포넌트 구현](https://github.com/Java-and-Script/pickple-front/commit/ff6e7a204d5f5c955210b6da4f1aa74125fccc9f)
[feat: router에 ScrollTop 컴포넌트 적용](https://github.com/Java-and-Script/pickple-front/commit/e57ec810ddd21e3691e842176b29d3fda7b41f69)
[refactor: ScrollTop 컴포넌트 useLayoutEffect 사용하게 변경](https://github.com/Java-and-Script/pickple-front/commit/74e276808277dca1af593d56a1abc96cc7eb4e3f)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

https://github.com/Java-and-Script/pickple-front/assets/81508534/a07d48ee-f638-4278-9556-65229f92e4cb


<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
