### PR TITLE
아이폰 사파리 regExp 오류 수정

### DIFF
--- a/src/pages/GamesDetailPage/GamesDetailPage.tsx
+++ b/src/pages/GamesDetailPage/GamesDetailPage.tsx
@@ -109,10 +109,6 @@ export const GamesDetailPage = () => {
     setIsPositionModalOpen((prev) => !prev);
   };
 
-  const formatCost = (cost: number) => {
-    return String(cost).replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',');
-  };
-
   return (
     <PageLayout>
       <Header />
@@ -216,7 +212,7 @@ export const GamesDetailPage = () => {
           <InfoItem>
             <GrayText size={12}>참가비</GrayText>
             <Image width={40} src={Money} alt="money" />
-            <Text size={16}>{`${formatCost(match.cost)}원`}</Text>
+            <Text size={16}>{`${match.cost.toLocaleString()}원`}</Text>
           </InfoItem>
           <InfoItem>
             <GrayText size={12}>현재원</GrayText>


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
아이폰 사파리에서 regExp 오류나서 게스트 모집 상세페이지가 렌더링되지 않는 문제
오류:  'SyntaxError: Invalid regular expression: invalid group specifier name'

## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 아이폰 사파리 regExp 오류 수정](https://github.com/Java-and-Script/pickple-front/pull/356/commits/1790d594a5dbf877d834f4488f4cea2c0f503a57)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
