### PR TITLE
카카오 맵 api parse blocking 경고 해결 및 global define 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,6 @@
       href="https://webfontworld.github.io/gmarket/GmarketSans.css"
       rel="stylesheet"
     />
-    <script>
-      var global = window;
-    </script>
     <title>픽플</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div id="root"></div>
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=bbbe0b7ffa94538537edc4f06caa9892&libraries=services,clusterer"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=bbbe0b7ffa94538537edc4f06caa9892&autoload=false&libraries=services,clusterer"
     ></script>
     <script type="module" src="/src/main.tsx"></script>
     <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,4 +33,7 @@ export default defineConfig({
       { find: '@mocks', replacement: '/src/mocks' },
     ],
   },
+  define: {
+    global: 'window',
+  },
 });


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
### 1. 카카오 맵 api parse blocking 경고
cdn이 로드 되기 전에 지도 객체에 접근하여 아래와 같은 경고가 발생했습니다.

<img width="672" alt="image" src="https://github.com/Java-and-Script/pickple-front/assets/87280835/f99e51fb-1e6a-4ff1-a039-cbd6c710b492">

`autoload=false`속성을 추가하여 cdn이 모두 로드된 후에 지도를 그리도록 설정해주었습니다.

### 2. socketjs-client global define
socketjs-client에서 `global`이 `undefined`여서 아래와 같은 문제가 발생했습니다.

<img width="557" alt="image" src="https://github.com/Java-and-Script/pickple-front/assets/87280835/612e82db-a82e-4540-8ada-4a49a0b3a8a1">

vite.config에서 global을 정의해 문제를 해결했습니다.
(이전에는 임시로 `index.html`에서 `var global=window`로 정의했었습니다.)
 
## 👨‍💻 구현 내용 or 👍 해결 내용
[chore: kakao map cdn에 autoload 속성 추가](https://github.com/Java-and-Script/pickple-front/pull/359/commits/5989608a4118b0071c32db6b0e8343e21e4f9be4) 

[chore: vite config에서 global 정의](https://github.com/Java-and-Script/pickple-front/pull/359/commits/a39a9693bf898c274894f11ef83e01f02ff451b2)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항
참고자료 [카카오 지도 load](https://apis.map.kakao.com/web/documentation/#load)
<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
