### PR TITLE
크루 아이템, 매치 아이템 ui 깨지는 버그

### DIFF
--- a/src/components/CrewItem/CrewItem.styles.ts
+++ b/src/components/CrewItem/CrewItem.styles.ts
@@ -10,6 +10,7 @@ export const CrewItemWrapper = styled(Flex)`
 `;
 
 export const CrewProfileImage = styled(Image)`
+  min-width: 82px;
   border-radius: 8px;
 `;
 

--- a/src/components/MatchItem/MatchItem.styles.ts
+++ b/src/components/MatchItem/MatchItem.styles.ts
@@ -21,6 +21,7 @@ export const MatchStatus = styled.div`
   flex-direction: column;
   background-color: ${({ theme }) => theme.PALETTE.GRAY_100};
   padding: 10px;
+  min-width: 82px;
   width: 82px;
   height: 82px;
   border-radius: 8px;

--- a/src/components/MatchItem/MatchItem.tsx
+++ b/src/components/MatchItem/MatchItem.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { Text } from '@components/shared/Text';
+
 import { theme } from '@styles/theme';
 
 import { PATH_NAME } from '@consts/pathName';
@@ -12,14 +14,12 @@ import { Avatar } from '../Avatar';
 import { AvatarGroup } from '../AvatarGroup';
 import {
   MatchAddress,
-  MatchDate,
   MatchDescription,
   MatchDuration,
   MatchItemInnerWrapper,
   MatchItemWrapper,
   MatchPlayerInfo,
   MatchRecruitmentStatus,
-  MatchStartTime,
   MatchStatus,
 } from './MatchItem.styles';
 import { BottomButton } from './components/BottomButton';
@@ -34,7 +34,6 @@ type MatchItemProps = {
   membersProfileImageUrls: string[];
 } & PropsWithChildren;
 
-/** TODO: Text 컴포넌트로 대체해야함 */
 const MatchItem = ({
   children,
   matchId,
@@ -54,22 +53,24 @@ const MatchItem = ({
       >
         <MatchStatus>
           {isGameEnded(startTime, timeMinutes) ? (
-            <MatchStartTime>종료</MatchStartTime>
+            <Text size={20} weight={700} nowrap>
+              종료
+            </Text>
           ) : (
             <>
-              <MatchStartTime>
+              <Text size={20} weight={700} nowrap>
                 {`${startTime.toTimeString().slice(0, 5)}`}
-              </MatchStartTime>
+              </Text>
               <MatchDuration>{`${timeMinutes / 60}h`}</MatchDuration>
             </>
           )}
         </MatchStatus>
         <MatchDescription>
-          <MatchDate>
+          <Text size={20} nowrap>
             {`${startTime.toLocaleDateString()} ${
               WEEKDAY[startTime.getDay()]
             }요일`}
-          </MatchDate>
+          </Text>
           <MatchAddress>{mainAddress}</MatchAddress>
           <MatchPlayerInfo>
             <AvatarGroup

--- a/src/pages/ChatRoomListPage/ChatRoomListPage.style.ts
+++ b/src/pages/ChatRoomListPage/ChatRoomListPage.style.ts
@@ -47,6 +47,7 @@ export const DateText = styled(Text)`
 `;
 
 export const ChatMatchStatus = styled(MatchStatus)`
+  min-width: 40px;
   width: 40px;
   height: 40px;
 `;


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
크루 아이템, 매치 아이템 ui 깨지는 버그

## 👨‍💻 구현 내용 or 👍 해결 내용
Text 컴포넌트로 변경하고 nowrap 속성 넣었습니다
작아지면 안되는 것들 min-width 넣었습니다.
게스트 모집 채팅 페이지에 쓰이는 ChatMatchStatus 에도 min-width 추가했습니다.

[fix: Crew, MatchItem ui 버그 수정](https://github.com/Java-and-Script/pickple-front/commit/11eef69fe1e5a43be90aa06ed7ffdc7cd5df3d00)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
