### PR TITLE
게스트 매치 상세 페이지 지도로 보기 구현

### DIFF
--- a/src/pages/GamesDetailPage/GameLocation.tsx
+++ b/src/pages/GamesDetailPage/GameLocation.tsx
@@ -1,0 +1,52 @@
+import toast from 'react-hot-toast';
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
+
+import { Game } from '@type/models';
+
+import MarkerSvg from '@assets/mapMarker.svg';
+
+type GameLocationProps = {
+  match: Game;
+};
+
+export const GameLocation = ({ match }: GameLocationProps) => {
+  return (
+    <Map
+      center={{ lat: match.latitude, lng: match.longitude }}
+      style={{ width: '100%', height: '300px' }}
+      level={4}
+    >
+      <MapMarker
+        position={{
+          lat: match.latitude,
+          lng: match.longitude,
+        }}
+        image={{
+          src: MarkerSvg,
+          size: {
+            width: 48,
+            height: 68,
+          },
+          options: {
+            offset: {
+              x: 23,
+              y: 55,
+            },
+          },
+        }}
+        onClick={() => copyLocation(match.mainAddress)}
+        clickable={true}
+      ></MapMarker>
+    </Map>
+  );
+};
+
+const copyLocation = async (location: Game['mainAddress']) => {
+  try {
+    await navigator.clipboard.writeText(location);
+
+    toast.success('위치 정보가 복사되었습니다.');
+  } catch (err) {
+    console.error('Failed to copy: ', err);
+  }
+};

--- a/src/pages/GamesDetailPage/GamesDetailPage.styles.ts
+++ b/src/pages/GamesDetailPage/GamesDetailPage.styles.ts
@@ -74,6 +74,7 @@ export const ButtonWrapper = styled.div`
   width: 100dvw;
   bottom: 70px;
   left: 0;
+  z-index: 1;
 `;
 
 export const PositionItemBox = styled.div`

--- a/src/pages/GamesDetailPage/GamesDetailPage.tsx
+++ b/src/pages/GamesDetailPage/GamesDetailPage.tsx
@@ -31,6 +31,7 @@ import Ball from '@assets/ball.svg';
 import GameMember from '@assets/gameMember.svg';
 import Money from '@assets/money.svg';
 
+import { GameLocation } from './GameLocation';
 import {
   ButtonWrapper,
   GrayText,
@@ -255,6 +256,10 @@ export const GamesDetailPage = () => {
             ))}
           </Guests>
         </GuestsContainer>
+        <Text size={20} weight={700}>
+          지도로 보기
+        </Text>
+        <GameLocation match={match} />
         <ButtonWrapper>
           {loginInfo && !isStarted && canParticipate && (
             <ErrorBoundary


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
게스트 매치 상세 페이지에 게임 위치를 지도로 볼 수 있는 기능을 구현했습니다.
마커를 클릭하면 위치 정보가 클립 보드에 복사됩니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: 지도로 보기 구현](https://github.com/Java-and-Script/pickple-front/commit/433b8216f8032d1973d200ff8ac1742917416ebc)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! --> 
<img width="395" alt="image" src="https://github.com/Java-and-Script/pickple-front/assets/87280835/64315d94-7fd6-48e9-8d22-8a481cfba19f">


<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
