### PR TITLE
크루 랭킹 페이지 모달 안뜨면서 렌더링 오류나는 버그

### DIFF
--- a/src/pages/CrewsRankingPage/CrewsRankingPage.tsx
+++ b/src/pages/CrewsRankingPage/CrewsRankingPage.tsx
@@ -79,7 +79,9 @@ export const CrewsRankingPage = () => {
               name={selectedCrewRank.name}
               ranking={selectedCrewRank.rank}
               infoText="랭킹은 활동점수와 매너지수를 기반으로 선정됩니다"
-              activityScore={selectedCrewRank.crewActivityScore}
+              activityScore={
+                selectedCrewRank.totalScore - selectedCrewRank.mannerScore
+              }
               mannerScore={selectedCrewRank.mannerScore}
               totalScore={selectedCrewRank.totalScore}
               addressDepth1={selectedCrewRank.addressDepth1}

--- a/src/type/models/CrewRank.ts
+++ b/src/type/models/CrewRank.ts
@@ -2,7 +2,6 @@ import { CrewProfile } from '.';
 
 export type CrewRank = {
   rank: number;
-  crewActivityScore: number;
   mannerScore: number;
   totalScore: number;
 } & Pick<


### PR DESCRIPTION
- CrewRank model 수정

## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
크루 랭킹 페이지 모달 안뜨면서 렌더링 오류나는 버그
만들어놓은 타입과 실제 api의 필드명이 달라서 생긴 버그입니다.

## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 크루 랭킹 관련 버그 수정](https://github.com/Java-and-Script/pickple-front/commit/597015d92901947e43deebe1097ec851caf2ced3)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
