### PR TITLE
모달 닫힐 때 ui 깨지는 버그

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -57,7 +57,7 @@ const Modal = ({ children, isOpen, header = false, close }: ModalProps) => {
         },
       }}
     >
-      {header !== false && (
+      {isOpen && header !== false && (
         <ModalHeader header={header === true ? 20 : header}>
           {/* TODO: svg fill 바꿔주기 */}
           <img
@@ -69,7 +69,7 @@ const Modal = ({ children, isOpen, header = false, close }: ModalProps) => {
           />
         </ModalHeader>
       )}
-      {children}
+      {isOpen && children}
     </BottomSheet>
   );
 };

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -57,7 +57,7 @@ const Modal = ({ children, isOpen, header = false, close }: ModalProps) => {
         },
       }}
     >
-      {isOpen && header !== false && (
+      {header !== false && (
         <ModalHeader header={header === true ? 20 : header}>
           {/* TODO: svg fill 바꿔주기 */}
           <img
@@ -69,7 +69,7 @@ const Modal = ({ children, isOpen, header = false, close }: ModalProps) => {
           />
         </ModalHeader>
       )}
-      {isOpen && children}
+      {children}
     </BottomSheet>
   );
 };

--- a/src/pages/CrewsRankingPage/CrewsRankingPage.tsx
+++ b/src/pages/CrewsRankingPage/CrewsRankingPage.tsx
@@ -70,10 +70,9 @@ export const CrewsRankingPage = () => {
           />
         ))}
       </PageContent>
-
-      <Modal header={40} isOpen={isOpen} close={() => setIsOpen(false)}>
-        <Modal.Content>
-          {selectedCrewRank && (
+      {selectedCrewRank && (
+        <Modal header={40} isOpen={isOpen} close={() => setIsOpen(false)}>
+          <Modal.Content>
             <RankingModalContent
               profileImageUrl={selectedCrewRank.profileImageUrl}
               name={selectedCrewRank.name}
@@ -90,9 +89,9 @@ export const CrewsRankingPage = () => {
               maxMemberCount={selectedCrewRank.maxMemberCount}
               onDetailButtonClick={handleDetailButtonClick}
             />
-          )}
-        </Modal.Content>
-      </Modal>
+          </Modal.Content>
+        </Modal>
+      )}
     </PageWrapper>
   );
 };

--- a/src/pages/CrewsRankingPage/CrewsRankingPage.tsx
+++ b/src/pages/CrewsRankingPage/CrewsRankingPage.tsx
@@ -71,7 +71,7 @@ export const CrewsRankingPage = () => {
         ))}
       </PageContent>
 
-      <Modal header={20} isOpen={isOpen} close={() => setIsOpen(false)}>
+      <Modal header={40} isOpen={isOpen} close={() => setIsOpen(false)}>
         <Modal.Content>
           {selectedCrewRank && (
             <RankingModalContent


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
모달 닫힐 때 ui 깨지는 버그

## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 모달 닫힐 때 ui깨지는 문제 수정](https://github.com/Java-and-Script/pickple-front/commit/dd46551b0bad351299860138e342d5383d798972)
[feat: 크루 랭킹 모달 핸들 크기 늘림](https://github.com/Java-and-Script/pickple-front/commit/78f3982c64e22a8aa30deb84d4b80e3bf91be852)
[fix: 크루 랭킹 페이지 모달 ui 깨지는 버그 2차 수정](https://github.com/Java-and-Script/pickple-front/commit/301c7a191094f5ce2147c92a2d625794ad4437fb)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

https://github.com/Java-and-Script/pickple-front/assets/81508534/8ed53c4e-fafb-4d8e-b295-2835e2b2ef1e


<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
