### PR TITLE
리뷰페이지 경기 호스트 id 제외 버그

### DIFF
--- a/src/pages/MannerScoreReviewPage/MannerScoreReviewPage.tsx
+++ b/src/pages/MannerScoreReviewPage/MannerScoreReviewPage.tsx
@@ -37,13 +37,13 @@ import { ToggleButton } from './ToggleButton';
 export const MannerScoreReviewPage = () => {
   const navigate = useNavigate();
   const gameId = Number(location.pathname.split('/')[2]);
-  const { data } = useGameDetailQuery(gameId);
+  const { data: gameData } = useGameDetailQuery(gameId);
   const loginInfo = useLoginInfoStore((state) => state.loginInfo);
-  const teammateListInfo = data.members.filter(({ id }) => {
+  const teammateListInfo = gameData.members.filter(({ id }) => {
     return loginInfo?.id !== id;
   });
   const nowDate = new Date();
-  const gameDate = new Date(`${data.playDate}T${data.playEndTime}`);
+  const gameDate = new Date(`${gameData.playDate}T${gameData.playEndTime}`);
 
   const exitCode =
     nowDate <= gameDate || !loginInfo || teammateListInfo.length === 0;
@@ -57,7 +57,7 @@ export const MannerScoreReviewPage = () => {
       mannerScore: -1 | 0 | 1;
     }[]
   >(
-    data.members.map(({ id }) => {
+    teammateListInfo.map(({ id }) => {
       return {
         memberId: id,
         mannerScore: 0,
@@ -66,7 +66,9 @@ export const MannerScoreReviewPage = () => {
   );
 
   const { mutate } = useMannerScoreReviewPatchMutation({
-    payload: { mannerScoreReviews: teammateList },
+    payload: {
+      mannerScoreReviews: teammateList,
+    },
     gameId: gameId,
   });
 


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
리뷰페이지에 본인을 제외한 팀원들의 목록을 만들어 놓았는데,
본인을 포함한 배열을 사용해서 발생하던 문제들이 수정되었습니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 본인을 제외한 참가자들의 목록 수정](https://github.com/Java-and-Script/pickple-front/commit/1e803faa2d7ded970501a201894ad7bd84333c75)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->
close #393
<!--## 완료 사항-->
