### PR TITLE
알림 목록 쿼리 getNextPageParam 수정

### DIFF
--- a/src/hooks/queries/useAlarmsQuery.ts
+++ b/src/hooks/queries/useAlarmsQuery.ts
@@ -14,9 +14,6 @@ export const useAlarmsQuery = () => {
       }),
 
     getNextPageParam: (lastPage) => {
-      if (!lastPage.cursorId === null) {
-        return undefined;
-      }
       return lastPage.cursorId;
     },
     initialPageParam: 0,

--- a/src/hooks/queries/useAlarmsQuery.ts
+++ b/src/hooks/queries/useAlarmsQuery.ts
@@ -14,7 +14,7 @@ export const useAlarmsQuery = () => {
       }),
 
     getNextPageParam: (lastPage) => {
-      if (!lastPage.hasNext) {
+      if (!lastPage.cursorId === null) {
         return undefined;
       }
       return lastPage.cursorId;


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
### 서버단에서 hasNext가 항상 false로 와서 cursorId가 null인지 아닌지로 hasNext 대체

알림 목록 쿼리 getNextPageParam 수정

## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 알림 목록 쿼리 getNextPageParam 수정](https://github.com/Java-and-Script/pickple-front/commit/7ce2218c873e03934e0d990c6a9e3390b7e8dc7a)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
