### PR TITLE
EventSource 로직 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,16 @@
-import toast, { Toaster } from 'react-hot-toast';
 import { RouterProvider } from 'react-router-dom';
 
 import { ThemeProvider } from '@emotion/react';
-import { InfiniteData, QueryClient } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import { router } from '@routes/router';
 
-import { useEventSource } from '@hooks/useEventSource';
-
 import GlobalStyle from '@styles/globalStyle';
 import { theme } from '@styles/theme';
 
-import { GetAlarmsResponse } from '@type/api/alarm';
+import { ConnectSSE } from './ConnectSSE';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,35 +22,13 @@ const queryClient = new QueryClient({
 });
 
 function App() {
-  useEventSource(
-    `${import.meta.env.VITE_BASE_URL}/alarms/subscribe`,
-    () => {
-      queryClient.resetQueries({ queryKey: ['alarms'] });
-      queryClient
-        .invalidateQueries({ queryKey: ['alarms-unread'] })
-        .then(() => {
-          const data = queryClient.getQueryData<
-            InfiniteData<GetAlarmsResponse, number>
-          >(['alarms']);
-          const alarms = data?.pages.flatMap((page) => page.alarmResponse);
-          alarms &&
-            toast(
-              'crewId' in alarms[0]
-                ? alarms[0].crewAlarmMessage
-                : alarms[0].gameAlarmMessage
-            );
-        });
-    },
-    (error) => console.log(error)
-  );
-
   return (
     <QueryClientProvider client={queryClient}>
+      <ConnectSSE />
       <ThemeProvider theme={theme}>
         <RouterProvider router={router} />
         <ReactQueryDevtools />
         <GlobalStyle />
-        <Toaster />
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/src/ConnectSSE.tsx
+++ b/src/ConnectSSE.tsx
@@ -1,0 +1,54 @@
+import toast from 'react-hot-toast';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { CrewNotificationItem } from '@pages/NotificationPage/components/CrewNotificationItem';
+import { GameNotificationItem } from '@pages/NotificationPage/components/GameNotificationItem';
+
+import { useEventSource } from '@hooks/useEventSource';
+
+import { Alarm } from '@type/models';
+
+export const ConnectSSE = () => {
+  const queryClient = useQueryClient();
+
+  useEventSource({
+    subscribeUrl: `${import.meta.env.VITE_BASE_URL}/alarms/subscribe`,
+    eventListenerParameters: [
+      [
+        'AlarmEvent',
+        (e) => {
+          queryClient.resetQueries({ queryKey: ['alarms'] });
+          queryClient.invalidateQueries({ queryKey: ['alarms-unread'] });
+
+          if ('data' in e) {
+            const newAlarm: Alarm = JSON.parse(e.data as string);
+            if ('crewId' in newAlarm) {
+              toast(
+                (t) => (
+                  <CrewNotificationItem
+                    alarm={newAlarm}
+                    onClick={() => toast.dismiss(t.id)}
+                  />
+                ),
+                { style: { padding: 0 } }
+              );
+            } else {
+              toast(
+                (t) => (
+                  <GameNotificationItem
+                    alarm={newAlarm}
+                    onClick={() => toast.dismiss(t.id)}
+                  />
+                ),
+                { style: { padding: 0 } }
+              );
+            }
+          }
+        },
+      ],
+    ],
+    onerror: (error) => console.log(error),
+  });
+  return null;
+};

--- a/src/hooks/useEventSource.ts
+++ b/src/hooks/useEventSource.ts
@@ -4,11 +4,19 @@ import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
 
 import { useLoginInfoStore } from '@stores/loginInfo.store';
 
-export const useEventSource = (
-  subscribeUrl: string,
-  onmessage: EventSourcePolyfill['onmessage'],
-  onerror?: EventSourcePolyfill['onerror']
-) => {
+export const useEventSource = ({
+  subscribeUrl,
+  eventListenerParameters = [],
+  onmessage,
+  onerror,
+}: {
+  subscribeUrl: string;
+  eventListenerParameters?: Parameters<
+    EventSourcePolyfill['addEventListener']
+  >[];
+  onmessage?: EventSourcePolyfill['onmessage'];
+  onerror?: EventSourcePolyfill['onerror'];
+}) => {
   const loginInfo = useLoginInfoStore((state) => state.loginInfo);
 
   useEffect(() => {
@@ -24,11 +32,15 @@ export const useEventSource = (
       },
     });
 
-    eventSource.onmessage = onmessage;
+    eventListenerParameters.map((eventListenerParameter) => {
+      eventSource.addEventListener(...eventListenerParameter);
+    });
+
+    onmessage && (eventSource.onmessage = onmessage);
     onerror && (eventSource.onerror = onerror);
 
     return () => {
       eventSource.close();
     };
-  }, [loginInfo, onmessage, onerror, subscribeUrl]);
+  }, [loginInfo, onmessage, onerror, subscribeUrl, eventListenerParameters]);
 };

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -5,8 +5,6 @@ import { Button } from '@components/shared/Button';
 import { Text } from '@components/shared/Text';
 
 import { useAlarmsDeleteMutation } from '@hooks/mutations/useAlarmsDeleteMutation';
-import { useCrewAlarmsPatchMutation } from '@hooks/mutations/useCrewAlarmsPatchMutation';
-import { useGameAlarmsPatchMutation } from '@hooks/mutations/useGameAlarmsPatchMutation';
 import { useAlarmsQuery } from '@hooks/queries/useAlarmsQuery';
 import { useInfiniteScroll } from '@hooks/useInfiniteScroll';
 
@@ -41,8 +39,6 @@ export const NotificationPage = () => {
   });
 
   const { mutate: deleteAlarmMutate } = useAlarmsDeleteMutation();
-  const { mutate: readCrewAlarmMutate } = useCrewAlarmsPatchMutation();
-  const { mutate: readGameAlarmMutate } = useGameAlarmsPatchMutation();
 
   return (
     <PageWrapper>
@@ -63,19 +59,11 @@ export const NotificationPage = () => {
         {alarms.map((alarm, index) => {
           if ('crewName' in alarm) {
             return (
-              <CrewNotificationItem
-                key={`alarm-key-${index}`}
-                alarm={alarm}
-                onClick={() => readCrewAlarmMutate(alarm.crewAlarmId)}
-              />
+              <CrewNotificationItem key={`alarm-key-${index}`} alarm={alarm} />
             );
           }
           return (
-            <GameNotificationItem
-              key={`alarm-key-${index}`}
-              alarm={alarm}
-              onClick={() => readGameAlarmMutate(alarm.gameAlarmId)}
-            />
+            <GameNotificationItem key={`alarm-key-${index}`} alarm={alarm} />
           );
         })}
         <div ref={entryRef} />

--- a/src/pages/NotificationPage/components/CrewNotificationItem/CrewNotificationItem.tsx
+++ b/src/pages/NotificationPage/components/CrewNotificationItem/CrewNotificationItem.tsx
@@ -2,11 +2,13 @@ import { useNavigate } from 'react-router-dom';
 
 import { NotificationItem } from '@components/NotificationItem';
 
+import { useCrewAlarmsPatchMutation } from '@hooks/mutations/useCrewAlarmsPatchMutation';
+
 import { CrewAlarm } from '@type/models';
 
 import { PATH_NAME } from '@consts/pathName';
 
-type CrewNotificationItemProps = { alarm: CrewAlarm; onClick: VoidFunction };
+type CrewNotificationItemProps = { alarm: CrewAlarm; onClick?: VoidFunction };
 
 const getRedirectMap = (
   crewId: string
@@ -21,6 +23,7 @@ export const CrewNotificationItem = ({
   onClick,
 }: CrewNotificationItemProps) => {
   const navigate = useNavigate();
+  const { mutate: readCrewAlarmMutate } = useCrewAlarmsPatchMutation();
 
   return (
     <NotificationItem
@@ -30,7 +33,8 @@ export const CrewNotificationItem = ({
       content={alarm.crewAlarmMessage}
       read={alarm.isRead}
       onClick={() => {
-        onClick();
+        onClick?.();
+        readCrewAlarmMutate(alarm.crewAlarmId);
         navigate(getRedirectMap(String(alarm.crewId))[alarm.crewAlarmMessage]);
       }}
     />

--- a/src/pages/NotificationPage/components/GameNotificationItem/GameNotificationItem.tsx
+++ b/src/pages/NotificationPage/components/GameNotificationItem/GameNotificationItem.tsx
@@ -2,6 +2,8 @@ import { useNavigate } from 'react-router-dom';
 
 import { NotificationItem } from '@/components/NotificationItem';
 
+import { useGameAlarmsPatchMutation } from '@hooks/mutations/useGameAlarmsPatchMutation';
+
 import { GameAlarm } from '@type/models';
 
 import { PATH_NAME } from '@consts/pathName';
@@ -10,7 +12,7 @@ import { getGameStartDate } from '@utils/domain';
 
 import { getGameNotificationTitle } from './getGameNotificationTitle';
 
-type GameNotificationItemProps = { alarm: GameAlarm; onClick: VoidFunction };
+type GameNotificationItemProps = { alarm: GameAlarm; onClick?: VoidFunction };
 
 const getRedirectMap = (
   gameId: string
@@ -26,6 +28,7 @@ export const GameNotificationItem = ({
   onClick,
 }: GameNotificationItemProps) => {
   const navigate = useNavigate();
+  const { mutate: readGameAlarmMutate } = useGameAlarmsPatchMutation();
 
   return (
     <NotificationItem
@@ -38,10 +41,10 @@ export const GameNotificationItem = ({
       title={getGameNotificationTitle(alarm.playDate, alarm.mainAddress)}
       createdAt={new Date(alarm.createdAt)}
       content={alarm.gameAlarmMessage}
-      // content={<GameNotificationContent alarmType={alarm.alarmType} />}
       read={alarm.isRead}
       onClick={() => {
-        onClick();
+        onClick?.();
+        readGameAlarmMutate(alarm.gameAlarmId);
         navigate(getRedirectMap(String(alarm.gameId))[alarm.gameAlarmMessage]);
       }}
     />

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { Toaster } from 'react-hot-toast';
 import { createBrowserRouter } from 'react-router-dom';
 
 import { AllServicesPage } from '@pages/AllServicesPage';
@@ -56,6 +57,7 @@ export const router = createBrowserRouter([
           <LoginRequireBoundary>
             <ScrollTop />
             <Layout />
+            <Toaster />
           </LoginRequireBoundary>
         </ErrorBoundary>
       </ErrorBoundary>


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
EventSource 로직 수정
백엔드에서 보내주는 AlarmEvent 에 맞게 로직을 수정했습니다.
알림이 오면 토스트가 띄워지고, 클릭 시 토스트가 닫히면서 연관 페이지로 이동하게 됩니다.

## 👨‍💻 구현 내용 or 👍 해결 내용
[refactor: 알림 아이템으로 navigate 로직 이동](https://github.com/Java-and-Script/pickple-front/commit/99d664eada9d6eb6501bc07be92b8c30409f7be2)
[feat: useEventSource 훅이 이벤트핸들러를 받을 수 있는 기능](https://github.com/Java-and-Script/pickple-front/commit/058cef40746baf53fd9ab619f37980645e630729)
[feat: AlarmEvent를 받는 기능 및 ConnectSSE 컴포넌트 구현](https://github.com/Java-and-Script/pickple-front/commit/639438411590caa5f264c6b8bea7171d00cd324e)
[feat: ConnectSSE 컴포넌트 App에 적용](https://github.com/Java-and-Script/pickple-front/commit/274fcee4bf1d66f36c37361b58e73c5a9a8e34f7)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
