### PR TITLE
게스트 매치 상세 페이지 포지션 클릭시 toast 출력으로 변경

### DIFF
--- a/src/pages/GamesDetailPage/GamesDetailPage.styles.ts
+++ b/src/pages/GamesDetailPage/GamesDetailPage.styles.ts
@@ -95,3 +95,9 @@ export const PositionItemBox = styled.div`
 export const ModalItem = styled(Flex)`
   padding: 16px;
 `;
+
+export const ToolTipText = styled(Text)`
+  padding: 0 2px;
+  border-radius: 5px;
+  border: 1px solid ${({ theme }) => theme.PALETTE.RED_400};
+`;

--- a/src/pages/GamesDetailPage/GamesDetailPage.tsx
+++ b/src/pages/GamesDetailPage/GamesDetailPage.tsx
@@ -1,26 +1,20 @@
-import { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import styled from '@emotion/styled';
-
 import { Avatar } from '@components/Avatar';
 import { Header } from '@components/Header';
-import { Modal } from '@components/Modal';
 import { Button } from '@components/shared/Button';
 import { Flex } from '@components/shared/Flex';
 import { Image } from '@components/shared/Image';
 import { Text } from '@components/shared/Text';
 
 import { useGameDetailQuery } from '@hooks/queries/useGameDetailQuery';
-import { usePositionsQuery } from '@hooks/queries/usePositionsQuery';
 import { useChatOnButtonClick } from '@hooks/useChatOnButtonClick';
+import { usePositionToast } from '@hooks/usePositionToast';
 
 import { theme } from '@styles/theme';
 
 import { useLoginInfoStore } from '@stores/loginInfo.store';
-
-import { Position, PositionInfo } from '@type/models/Position';
 
 import { PATH_NAME } from '@consts/pathName';
 import { WEEKDAY } from '@consts/weekday';
@@ -39,11 +33,11 @@ import {
   Guests,
   GuestsContainer,
   InfoItem,
-  ModalItem,
   PageContent,
   PageLayout,
   PositionItemBox,
   TextContainer,
+  ToolTipText,
   UserDataWrapper,
 } from './GamesDetailPage.styles';
 import { GuestButton } from './components/GuestButton';
@@ -56,14 +50,10 @@ export const GamesDetailPage = () => {
   }
 
   const navigate = useNavigate();
-  const [isPositionModalOpen, setIsPositionModalOpen] = useState(false);
-  const [clickedPositionInfo, setClickedPositionInfo] =
-    useState<PositionInfo | null>(null);
 
   const gameId = Number(id);
 
   const { data: match } = useGameDetailQuery(gameId);
-  const { data: positions } = usePositionsQuery();
 
   const loginInfo = useLoginInfoStore((state) => state.loginInfo);
   const isMyMatch = match.host.id === loginInfo?.id;
@@ -90,22 +80,7 @@ export const GamesDetailPage = () => {
     navigate,
     myId: loginInfo?.id ?? null,
   });
-
-  const handleClickPosition = (myPosition: Position) => {
-    const positionInfo = positions.find(
-      (position) => position.acronym === myPosition
-    );
-
-    if (!positionInfo) {
-      return;
-    }
-    setClickedPositionInfo(positionInfo);
-    setIsPositionModalOpen(true);
-  };
-
-  const togglePositionModal = () => {
-    setIsPositionModalOpen((prev) => !prev);
-  };
+  const { handleClickPosition } = usePositionToast();
 
   return (
     <PageLayout>
@@ -213,18 +188,6 @@ export const GamesDetailPage = () => {
               </PositionItemBox>
             ))}
           </Flex>
-          <Modal isOpen={isPositionModalOpen} close={togglePositionModal}>
-            {clickedPositionInfo && (
-              <Modal.Content>
-                <ModalItem direction="column" align="center" gap={8}>
-                  <Text size={24} weight={700}>
-                    {clickedPositionInfo.name}
-                  </Text>
-                  <Text>{clickedPositionInfo.description}</Text>
-                </ModalItem>
-              </Modal.Content>
-            )}
-          </Modal>
         </Flex>
         <Flex gap={10}>
           <InfoItem>
@@ -317,9 +280,3 @@ export const GamesDetailPage = () => {
     </PageLayout>
   );
 };
-
-const ToolTipText = styled(Text)`
-  padding: 0 2px;
-  border-radius: 5px;
-  border: 1px solid ${({ theme }) => theme.PALETTE.RED_400};
-`;


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
[refactor: 게스트 매치 상세 페이지 포지션 클릭시 toast 출력으로 변경](https://github.com/Java-and-Script/pickple-front/commit/0fd924923540be38829a0dc04cb87a63877bd5bd)
## 👨‍💻 구현 내용 or 👍 해결 내용
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
![스크린샷 2023-11-30 오후 3 09 59](https://github.com/Java-and-Script/pickple-front/assets/71740032/99f3e45d-967d-4bb2-b181-4beb4db31a6a)

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트
이전에 선호 포지션을 클릭하면 모달창으로 출력되었던 포지션에 대한 정보를 toast로 출력되게 변경했습니다!
<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
