### PR TITLE
게임/크루 참여 관리 페이지 토스트에 에러코드 반영

### DIFF
--- a/src/hooks/mutations/useAllowCrewParticipateMutation.ts
+++ b/src/hooks/mutations/useAllowCrewParticipateMutation.ts
@@ -2,6 +2,7 @@ import toast from 'react-hot-toast';
 
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 import { patchCrewParticipate } from '@api/crews/patchCrewParticipate';
 
@@ -19,8 +20,18 @@ export const useAllowCrewParticipateMutation = () => {
         queryKey: ['crew-members', crewId, '대기'],
       });
     },
-    onError: () => {
-      toast.error('크루 가입를 수락하지 못 했습니다. 다시 한 번 시도해주세요.');
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.data.code === 'CRE-006') {
+          return toast.error('크루의 정원을 초과했습니다.');
+        }
+        if (error.response?.data.code === 'CRE-009') {
+          return toast.error('권한이 없습니다.');
+        }
+      }
+      toast.error(
+        '크루 가입 수락에 실패했어요.\n새로고침 후, 다시 한 번 시도해주세요.'
+      );
     },
   });
 };

--- a/src/hooks/mutations/useAllowCrewParticipateMutation.ts
+++ b/src/hooks/mutations/useAllowCrewParticipateMutation.ts
@@ -22,10 +22,12 @@ export const useAllowCrewParticipateMutation = () => {
     },
     onError: (error) => {
       if (error instanceof AxiosError) {
-        if (error.response?.data.code === 'CRE-006') {
+        const errorCode = error.response?.data.code;
+
+        if (errorCode === 'CRE-006' || errorCode === 'CHT-004') {
           return toast.error('크루의 정원을 초과했습니다.');
         }
-        if (error.response?.data.code === 'CRE-009') {
+        if (errorCode === 'CRE-009') {
           return toast.error('권한이 없습니다.');
         }
       }

--- a/src/hooks/mutations/useAllowGameParticipateMutation.ts
+++ b/src/hooks/mutations/useAllowGameParticipateMutation.ts
@@ -22,10 +22,12 @@ export const useAllowGameParticipateMutation = () => {
     },
     onError: (error) => {
       if (error instanceof AxiosError) {
-        if (error.response?.data.code === 'GAM-013') {
+        const errorCode = error.response?.data.code;
+
+        if (errorCode === 'GAM-013' || errorCode === 'CHT-004') {
           return toast.error('게스트 모집 정원을 초과했습니다.');
         }
-        if (error.response?.data.code === 'GAM-010') {
+        if (errorCode === 'GAM-010') {
           return toast.error('권한이 없습니다.');
         }
       }

--- a/src/hooks/mutations/useAllowGameParticipateMutation.ts
+++ b/src/hooks/mutations/useAllowGameParticipateMutation.ts
@@ -2,6 +2,7 @@ import toast from 'react-hot-toast';
 
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 import { patchGameParticipate } from '@api/games/patchGameParticipate';
 
@@ -19,8 +20,19 @@ export const useAllowGameParticipateMutation = () => {
         queryKey: ['game-members', gameId, '대기'],
       });
     },
-    onError: () => {
-      toast.error('게임 참여를 수락하지 못 했습니다. 다시 한 번 시도해주세요.');
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.data.code === 'GAM-013') {
+          return toast.error('게스트 모집 정원을 초과했습니다.');
+        }
+        if (error.response?.data.code === 'GAM-010') {
+          return toast.error('권한이 없습니다.');
+        }
+      }
+
+      toast.error(
+        '게임 참여 수락에 실패했어요.\n새로고침 후, 다시 한 번 시도해주세요.'
+      );
     },
   });
 };

--- a/src/hooks/mutations/useDisallowCrewParticipateMutation.ts
+++ b/src/hooks/mutations/useDisallowCrewParticipateMutation.ts
@@ -2,6 +2,7 @@ import toast from 'react-hot-toast';
 
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 import { deleteCrewParticipate } from '@api/crews/deleteCrewParticipate';
 
@@ -19,8 +20,16 @@ export const useDisallowCrewParticipateMutation = () => {
         queryKey: ['crew-members', crewId, '대기'],
       });
     },
-    onError: () => {
-      toast.error('크루 가입를 거절하지 못 했습니다. 다시 한 번 시도해주세요.');
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.data.code === 'CRE-009') {
+          return toast.error('권한이 없습니다.');
+        }
+      }
+
+      toast.error(
+        '크루 가입 거절에 실패했어요.\n새로고침 후, 다시 한 번 시도해주세요.'
+      );
     },
   });
 };

--- a/src/hooks/mutations/useDisallowGameParticipateMutation.ts
+++ b/src/hooks/mutations/useDisallowGameParticipateMutation.ts
@@ -2,6 +2,7 @@ import toast from 'react-hot-toast';
 
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 import { deleteGameParticipate } from '@api/games/deleteGameParticipate';
 
@@ -19,8 +20,16 @@ export const useRefuseGameParticipateMutation = () => {
         queryKey: ['game-members', gameId, '대기'],
       });
     },
-    onError: () => {
-      toast.error('게임 참여를 거절하지 못 했습니다. 다시 한 번 시도해주세요.');
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.data.code === 'GAM-010') {
+          return toast.error('권한이 없습니다.');
+        }
+      }
+
+      toast.error(
+        '게임 참여 거절에 실패했어요.\n새로고침 후, 다시 한 번 시도해주세요.'
+      );
     },
   });
 };


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
게임/크루 참여 관리 페이지 토스트에 에러코드를 반영하였습니다.
정원이 초과되거나 권한이 없으면 토스트에 에러 메세지가 출력됩니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: 게임 참여 관리 페이지 토스트에 에러코드 반영](https://github.com/Java-and-Script/pickple-front/commit/570f1c7e964e443fd5a3cc2f59b4d7e169765a5c)
 
[feat: 크루 가입 관리 페이지 토스트에 에러코드 반영](https://github.com/Java-and-Script/pickple-front/commit/74955dcd4cc7bf8151ae79e59051a303659329d4)

[fix: 정원 초과에 대한 에러코드 추가](https://github.com/Java-and-Script/pickple-front/pull/422/commits/4b5d9ecfb9f7ef2bec81d4350a6c5d0e0c52038a)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
