### PR TITLE
토스트 클릭으로 페이지 이동 시 다음 토스트들이 닫히지 않는 버그

### DIFF
--- a/src/ConnectSSE.tsx
+++ b/src/ConnectSSE.tsx
@@ -31,7 +31,7 @@ export const ConnectSSE = () => {
                     onClick={() => toast.dismiss(t.id)}
                   />
                 ),
-                { style: { padding: 0 } }
+                { style: { padding: 0 }, duration: 4000 }
               );
             } else {
               toast(
@@ -41,7 +41,7 @@ export const ConnectSSE = () => {
                     onClick={() => toast.dismiss(t.id)}
                   />
                 ),
-                { style: { padding: 0 } }
+                { style: { padding: 0 }, duration: 4000 }
               );
             }
           }

--- a/src/hooks/useEventSource.ts
+++ b/src/hooks/useEventSource.ts
@@ -30,6 +30,7 @@ export const useEventSource = ({
         Authorization: `Bearer ${loginInfo.accessToken}`,
         'Content-type': 'text/event-stream',
       },
+      heartbeatTimeout: 1000 * 60 * 60 * 6,
     });
 
     eventListenerParameters.map((eventListenerParameter) => {

--- a/src/routes/ToastResume.tsx
+++ b/src/routes/ToastResume.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useToaster } from 'react-hot-toast';
+import { useLocation } from 'react-router-dom';
+
+/** 페이지 이동 시 토스트의 pause를 풀어줍니다 */
+export const ToastResume = () => {
+  const { pathname } = useLocation();
+  const { handlers } = useToaster();
+
+  useEffect(() => {
+    handlers.endPause();
+  }, [pathname, handlers]);
+
+  return null;
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -57,7 +57,7 @@ export const router = createBrowserRouter([
           <LoginRequireBoundary>
             <ScrollTop />
             <Layout />
-            <Toaster />
+            <Toaster toastOptions={{ duration: 2000 }} />
           </LoginRequireBoundary>
         </ErrorBoundary>
       </ErrorBoundary>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -26,6 +26,7 @@ import { ManagePageSkeleton } from '@pages/__components__/ManagePageSkeleton';
 
 import { LoginRequireBoundary } from './LoginRequireBoundary';
 import { ScrollTop } from './ScrollTop';
+import { ToastResume } from './ToastResume';
 import {
   ChattingPage,
   CreateCrewPage,
@@ -56,6 +57,7 @@ export const router = createBrowserRouter([
         <ErrorBoundary FallbackComponent={AuthErrorPage}>
           <LoginRequireBoundary>
             <ScrollTop />
+            <ToastResume />
             <Layout />
             <Toaster toastOptions={{ duration: 2000 }} />
           </LoginRequireBoundary>


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
토스트 클릭으로 페이지 이동 시 다음 토스트들이 닫히지 않는 버그

## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: toast 기본 duration 적용](https://github.com/Java-and-Script/pickple-front/commit/869a2696e0803b6dcff428ab62ec0250a1826cc9)
[feat: SSE 연결 대기시간을 accessToken 만료 시간과 동일하게 변경](https://github.com/Java-and-Script/pickple-front/commit/dc25937e1d7157ac5909e33c87e93f4dfe2be3f8)
[feat: 알림 토스트 duration 4초로 적용](https://github.com/Java-and-Script/pickple-front/commit/beb8a6df23fa86213141141a1f956a57edc3d0a9)
[hotfix: ToastResume 컴포넌트를 통해 토스트 버그 해결](https://github.com/Java-and-Script/pickple-front/commit/fd0df31211ec6f7edaf5ae021e17d82cb9831e70)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
