### PR TITLE
글쓰기 페이지들 가상 스크롤 사용하는 로직 수정

### DIFF
--- a/src/pages/CreateCrewPage/CreateCrewPage.tsx
+++ b/src/pages/CreateCrewPage/CreateCrewPage.tsx
@@ -38,7 +38,7 @@ export const CreateCrewPage = () => {
     onSubmit,
     setName,
     setContent,
-    setMaxMemberCount,
+    handleMaxMemberCount,
     handleToggleLocation,
     toggleMaxMemberCountModal,
     toggleAddressDepth2Modal,
@@ -89,7 +89,7 @@ export const CreateCrewPage = () => {
               <VirtualScroll
                 width="100%"
                 list={[...MAX_MEMBER_COUNT_LIST]}
-                onItemSelected={setMaxMemberCount}
+                onItemSelected={handleMaxMemberCount}
               />
             </ConditionalFormInput>
             <Text size={16} weight={300}>

--- a/src/pages/CreateCrewPage/useCreateCrewPage.ts
+++ b/src/pages/CreateCrewPage/useCreateCrewPage.ts
@@ -83,6 +83,10 @@ export const useCreateCrewPage = () => {
     setIsOpenAddressDepth2Modal((prev) => !prev);
   };
 
+  const handleMaxMemberCount = (maxMemberCount: string) => {
+    isOpenMaxMemberCountModal || setMaxMemberCount(maxMemberCount);
+  };
+
   return {
     state: {
       name,
@@ -97,7 +101,7 @@ export const useCreateCrewPage = () => {
     onSubmit,
     setName,
     setContent,
-    setMaxMemberCount,
+    handleMaxMemberCount,
     handleToggleLocation,
     toggleMaxMemberCountModal,
     toggleAddressDepth2Modal,

--- a/src/pages/CreateGamePage/CreateGamePage.tsx
+++ b/src/pages/CreateGamePage/CreateGamePage.tsx
@@ -44,14 +44,14 @@ export const CreateGamePage = () => {
     toggleMatchDateModal,
     toggleStartTimeModal,
     togglePlayTimeModal,
-    setMaxMemberCount,
     setPlayDate,
-    setPlayStartTimeHours,
-    setPlayStartTimeMinutes,
-    setPlayTimeMinutes,
     setPositions,
     setDetailAddress,
     setContent,
+    handleMaxMemberCount,
+    handlePlayStartTimeHours,
+    handlePlayStartTimeMinutes,
+    handlePlayTimeMinutes,
   } = useCreateGamePage();
 
   const { entryRef, showHeaderTitle } = useHeaderTitle<HTMLDivElement>();
@@ -97,7 +97,7 @@ export const CreateGamePage = () => {
               <VirtualScroll
                 width="100%"
                 list={[...MAX_MEMBER_COUNT_LIST]}
-                onItemSelected={setMaxMemberCount}
+                onItemSelected={handleMaxMemberCount}
               />
             </ConditionalFormInput>
             <ConditionalFormInput
@@ -126,13 +126,13 @@ export const CreateGamePage = () => {
                 <VirtualScroll
                   width="20%"
                   list={[...START_TIME_HOUR_LIST]}
-                  onItemSelected={setPlayStartTimeHours}
+                  onItemSelected={handlePlayStartTimeHours}
                 />
                 <StyledTimeColon>{':'}</StyledTimeColon>
                 <VirtualScroll
                   width="20%"
                   list={[...START_TIME_MINUTES_LIST]}
-                  onItemSelected={setPlayStartTimeMinutes}
+                  onItemSelected={handlePlayStartTimeMinutes}
                 />
               </StyledTimeSelector>
             </ConditionalFormInput>
@@ -149,7 +149,7 @@ export const CreateGamePage = () => {
               <VirtualScroll
                 width="100%"
                 list={[...PLAY_TIME_LIST]}
-                onItemSelected={setPlayTimeMinutes}
+                onItemSelected={handlePlayTimeMinutes}
               />
             </ConditionalFormInput>
             <Text size={16} weight={300}>

--- a/src/pages/CreateGamePage/useCreateGamePage.ts
+++ b/src/pages/CreateGamePage/useCreateGamePage.ts
@@ -47,6 +47,54 @@ export const useCreateGamePage = () => {
   const [isPlayTimeModalOpen, setIsPlayTimeModalOpen] =
     useState<boolean>(false);
 
+  const handleMaxMemberCount = (maxMemberCount: string) => {
+    isGuestCountModalOpen || setMaxMemberCount(maxMemberCount);
+  };
+
+  const handlePlayStartTimeHours = (playStartTimeHours: string) => {
+    isStartTimeModalOpen || setPlayStartTimeHours(playStartTimeHours);
+  };
+
+  const handlePlayStartTimeMinutes = (playStartTimeMinutes: string) => {
+    isStartTimeModalOpen || setPlayStartTimeMinutes(playStartTimeMinutes);
+  };
+
+  const handlePlayTimeMinutes = (playTimeMinutes: string) => {
+    isPlayTimeModalOpen || setPlayTimeMinutes(playTimeMinutes);
+  };
+
+  const handleAddressSelect = () => {
+    new daum.Postcode({
+      oncomplete: ({ address }: { address: string }) => {
+        setMainAddress(address);
+      },
+    }).open();
+  };
+
+  const handleCost = (item: string) => {
+    if (parseInt(item) < 0) {
+      setCost('0');
+    } else if (parseInt(item) > 100000) {
+      setCost('100000');
+    } else setCost(item);
+  };
+
+  const toggleGuestCountModal = () => {
+    setIsGuestCountModalOpen((prev) => !prev);
+  };
+
+  const toggleMatchDateModal = () => {
+    setIsMatchDateModalOpen((prev) => !prev);
+  };
+
+  const toggleStartTimeModal = () => {
+    setIsStartTimeModalOpen((prev) => !prev);
+  };
+
+  const togglePlayTimeModal = () => {
+    setIsPlayTimeModalOpen((prev) => !prev);
+  };
+
   const onSubmit = () => {
     const gameData: PostGameRequest = {
       maxMemberCount: parseInt(maxMemberCount),
@@ -107,38 +155,6 @@ export const useCreateGamePage = () => {
     return true;
   };
 
-  const handleAddressSelect = () => {
-    new daum.Postcode({
-      oncomplete: ({ address }: { address: string }) => {
-        setMainAddress(address);
-      },
-    }).open();
-  };
-
-  const handleCost = (item: string) => {
-    if (parseInt(item) < 0) {
-      setCost('0');
-    } else if (parseInt(item) > 100000) {
-      setCost('100000');
-    } else setCost(item);
-  };
-
-  const toggleGuestCountModal = () => {
-    setIsGuestCountModalOpen((prev) => !prev);
-  };
-
-  const toggleMatchDateModal = () => {
-    setIsMatchDateModalOpen((prev) => !prev);
-  };
-
-  const toggleStartTimeModal = () => {
-    setIsStartTimeModalOpen((prev) => !prev);
-  };
-
-  const togglePlayTimeModal = () => {
-    setIsPlayTimeModalOpen((prev) => !prev);
-  };
-
   return {
     state: {
       maxMemberCount,
@@ -161,16 +177,16 @@ export const useCreateGamePage = () => {
     toggleMatchDateModal,
     toggleStartTimeModal,
     togglePlayTimeModal,
-    setMaxMemberCount,
     setPlayDate,
-    setPlayStartTimeHours,
-    setPlayStartTimeMinutes,
-    setPlayTimeMinutes,
     setPositions,
     setDetailAddress,
     setContent,
     onSubmit,
     handleAddressSelect,
     handleCost,
+    handleMaxMemberCount,
+    handlePlayStartTimeHours,
+    handlePlayStartTimeMinutes,
+    handlePlayTimeMinutes,
   };
 };


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
이전에는 스크롤을 올리고 내릴 때 마다 페이지의 input value가 변하게 만들어서 페이지에서 렌더링이 자주 발생했는데
모달이 닫힐 때만 input value가 변하게 만들어서 렌더링 횟수를 줄였습니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[refactor: 크루 만들기 페이지 가상스크롤 들어가는 select 함수 수정](https://github.com/Java-and-Script/pickple-front/commit/99db66ab31b29978f093a41c7ce83eb0e704574f)
[refactor: 게스트 모집글 생성 페이지 가상스크롤 사용 로직 변경](https://github.com/Java-and-Script/pickple-front/commit/8c25f9cd4cb01fb560e694b42bfa4cdfe09d6a9e)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
