### PR TITLE
채팅방 페이지 메뉴 내 대화 상대 목록 보기, 상세페이지 이동 구현

### DIFF
--- a/src/pages/ChattingPage/ChattingPage.style.ts
+++ b/src/pages/ChattingPage/ChattingPage.style.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import { Flex } from '@components/shared/Flex';
+import { Text } from '@components/shared/Text';
 
 import { CHAT_TYPE } from '@constants/chat';
 
@@ -76,6 +77,20 @@ export const ModalItem = styled.div`
   cursor: pointer;
 `;
 
-export const Pointer = styled.div`
+export const RoomNameWrapper = styled.div`
   cursor: pointer;
+`;
+
+export const FlexModalItem = styled(Flex)`
+  padding: 14px 20px;
+  cursor: pointer;
+`;
+
+export const AlignedCenteredText = styled(Text)`
+  text-align: center;
+  width: 100%;
+`;
+
+export const ProfileListContainer = styled.div`
+  max-height: 60vh;
 `;

--- a/src/pages/ChattingPage/ChattingPage.tsx
+++ b/src/pages/ChattingPage/ChattingPage.tsx
@@ -1,32 +1,41 @@
 import Hamburger from '@/assets/hamburger.svg?react';
 
+import { Avatar } from '@components/Avatar';
 import { Header } from '@components/Header';
 import { Modal } from '@components/Modal';
 import { Input } from '@components/shared/Input';
+import { Text } from '@components/shared/Text';
 
 import { theme } from '@styles/theme';
 
 import { PATH_NAME } from '@constants/pathName';
 
 import {
+  AlignedCenteredText,
   ChatRoomContainer,
+  FlexModalItem,
   InputWrapper,
   Main,
   ModalItem,
+  ProfileListContainer,
   SendButton,
 } from './ChattingPage.style';
 import { Chat } from './components/Chat';
 import { ChatRoomTitle } from './components/ChatRoomTitle';
+import { PageMoveModalItem } from './components/PageMoveModalItem';
+import { MODAL_CONTENTS } from './constants/modalContents';
 import { useChattingPage } from './hooks/useChattingPage';
 
 export const ChattingPage = () => {
   const {
-    roomDetails: { type: roomType, domainId, roomName },
+    roomDetails: { type: roomType, domainId, roomName, members },
     chatMessages,
     myId,
     isModalOpen,
     inputRef,
     chattingEndRef,
+    modalContents,
+    setModalContents,
     setIsModalOpen,
     moveToPage,
     sendChatMessage,
@@ -76,9 +85,48 @@ export const ChattingPage = () => {
         </Input>
       </InputWrapper>
       <Modal isOpen={isModalOpen} close={() => setIsModalOpen(false)}>
-        <Modal.Content>
-          <ModalItem onClick={quitChatting}>채팅방 나가기</ModalItem>
-        </Modal.Content>
+        {modalContents === MODAL_CONTENTS.DEFAULT ? (
+          <Modal.Content>
+            <ModalItem
+              onClick={() => {
+                setModalContents(MODAL_CONTENTS.CHAT_MEMBERS);
+              }}
+            >
+              대화 상대
+            </ModalItem>
+            <PageMoveModalItem
+              id={domainId}
+              type={roomType}
+              onClick={moveToPage}
+            />
+            <ModalItem onClick={quitChatting}>채팅방 나가기</ModalItem>
+          </Modal.Content>
+        ) : (
+          <Modal.Content>
+            <FlexModalItem
+              onClick={() => {
+                setModalContents(MODAL_CONTENTS.DEFAULT);
+              }}
+            >
+              <Text>{'< '}</Text>
+              <AlignedCenteredText>대화 상대</AlignedCenteredText>
+            </FlexModalItem>
+            <ProfileListContainer>
+              {members.map((members) => (
+                <FlexModalItem
+                  gap={8}
+                  align="center"
+                  onClick={() =>
+                    moveToPage(PATH_NAME.GET_PROFILE_PATH(String(members.id)))
+                  }
+                >
+                  <Avatar src={members.profileImageUrl} />
+                  <Text weight={500}>{members.nickname}</Text>
+                </FlexModalItem>
+              ))}
+            </ProfileListContainer>
+          </Modal.Content>
+        )}
       </Modal>
       <div ref={chattingEndRef}></div>
     </>

--- a/src/pages/ChattingPage/components/ChatRoomTitle.tsx
+++ b/src/pages/ChattingPage/components/ChatRoomTitle.tsx
@@ -1,35 +1,26 @@
 import { ChatRoomDetail } from '@type/models/ChatRoom';
 
-import { CHAT_ROOM_TAB_TITLE } from '@constants/chat';
-import { PATH_NAME } from '@constants/pathName';
+import { RoomNameWrapper } from '../ChattingPage.style';
+import { PAGE_PATH_BY_ROOM_TYPE } from '../constants/chatRoomTypeOptions';
 
-import { Pointer } from '../ChattingPage.style';
+type ChatRoomTitleProps = Pick<
+  ChatRoomDetail,
+  'type' | 'domainId' | 'roomName'
+> & {
+  onClick: (path: string) => void;
+};
 
 export const ChatRoomTitle = ({
-  type,
+  type: roomType,
   domainId,
   roomName,
   onClick: moveToPage,
-}: Pick<ChatRoomDetail, 'type' | 'domainId' | 'roomName'> & {
-  onClick: (path: string) => void;
-}) => {
-  const titlePagePath = getTitlePagePath(type);
+}: ChatRoomTitleProps) => {
+  const path = PAGE_PATH_BY_ROOM_TYPE[roomType](String(domainId));
 
   return (
-    <Pointer onClick={() => moveToPage(titlePagePath(String(domainId)))}>
+    <RoomNameWrapper onClick={() => moveToPage(path)}>
       {roomName}
-    </Pointer>
+    </RoomNameWrapper>
   );
-};
-
-const getTitlePagePath = (roomType: string) => {
-  if (roomType === CHAT_ROOM_TAB_TITLE.INDIVIDUAL) {
-    return PATH_NAME.GET_PROFILE_PATH;
-  }
-
-  if (roomType === CHAT_ROOM_TAB_TITLE.GUEST) {
-    return PATH_NAME.GET_GAMES_PATH;
-  }
-
-  return PATH_NAME.GET_CREWS_PATH;
 };

--- a/src/pages/ChattingPage/components/PageMoveModalItem.tsx
+++ b/src/pages/ChattingPage/components/PageMoveModalItem.tsx
@@ -1,0 +1,23 @@
+import { ChatRoom } from '@type/models/ChatRoom';
+
+import { ModalItem } from '../ChattingPage.style';
+import {
+  PAGE_MOVE_MODAL_ITEM_TITLE,
+  PAGE_PATH_BY_ROOM_TYPE,
+} from '../constants/chatRoomTypeOptions';
+
+type PageMoveModalItem = Pick<ChatRoom, 'type' | 'id'> & {
+  onClick: (id: string) => void;
+};
+
+export const PageMoveModalItem = ({
+  type: roomType,
+  id: domainId,
+  onClick: moveToPage,
+}: PageMoveModalItem) => {
+  const title = PAGE_MOVE_MODAL_ITEM_TITLE[roomType];
+
+  const path = PAGE_PATH_BY_ROOM_TYPE[roomType](String(domainId));
+
+  return <ModalItem onClick={() => moveToPage(path)}>{title}</ModalItem>;
+};

--- a/src/pages/ChattingPage/constants/chatRoomTypeOptions.ts
+++ b/src/pages/ChattingPage/constants/chatRoomTypeOptions.ts
@@ -1,0 +1,18 @@
+import { ChatRoom } from '@type/models/ChatRoom';
+
+import { PATH_NAME } from '@constants/pathName';
+
+export const PAGE_MOVE_MODAL_ITEM_TITLE: Record<ChatRoom['type'], string> = {
+  개인: '상대방 프로필 페이지로 이동하기',
+  게스트: '게스트 모집글 페이지로 이동하기',
+  크루: '크루 상세 페이지로 이동하기',
+};
+
+export const PAGE_PATH_BY_ROOM_TYPE: Record<
+  ChatRoom['type'],
+  (id: string) => string
+> = {
+  개인: PATH_NAME.GET_PROFILE_PATH,
+  게스트: PATH_NAME.GET_GAMES_PATH,
+  크루: PATH_NAME.GET_CREWS_PATH,
+};

--- a/src/pages/ChattingPage/constants/modalContents.ts
+++ b/src/pages/ChattingPage/constants/modalContents.ts
@@ -1,0 +1,4 @@
+export const MODAL_CONTENTS = {
+  DEFAULT: '기본',
+  CHAT_MEMBERS: '대화 상대',
+};

--- a/src/pages/ChattingPage/hooks/useChattingPage.ts
+++ b/src/pages/ChattingPage/hooks/useChattingPage.ts
@@ -18,6 +18,7 @@ import { ChatMessage } from '@type/models/ChatMessage';
 import { CHAT_TYPE } from '@constants/chat';
 import { PATH_NAME } from '@constants/pathName';
 
+import { MODAL_CONTENTS } from '../constants/modalContents';
 import { formatDateString, getKoreanDay } from '../services/formatDate';
 import { useQuitCondition } from '../services/quitChatCondition';
 import {
@@ -57,6 +58,7 @@ export const useChattingPage = () => {
   const [stompClient, setStompClient] = useState<Stomp.Client | null>(null);
   const [chatMessages, setChatMessages] = useState(prevChatMessages);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalContents, setModalContents] = useState(MODAL_CONTENTS.DEFAULT);
 
   const chattingEndRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -190,6 +192,8 @@ export const useChattingPage = () => {
     isModalOpen,
     inputRef,
     chattingEndRef,
+    modalContents,
+    setModalContents,
     setIsModalOpen,
     moveToPage,
     sendChatMessage,


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
채팅방 페이지 메뉴에 대화 상대 목록 보기와 상세페이지 이동 구현했습니다.

## 👨‍💻 구현 내용 or 👍 해결 내용
[refactor: 체팅방 페이지 내 상수화](https://github.com/Java-and-Script/pickple-front/commit/a70d1a8dba9315ca24fbc20e3954fce4485ac9ee)
 
[feat: 채팅방 메뉴 내 대화상대 목록, 상세 페이지 이동 구현](https://github.com/Java-and-Script/pickple-front/commit/c5f455d6e48361320c75aed8d349bd3688981989)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<img width="376" alt="image" src="https://github.com/Java-and-Script/pickple-front/assets/87280835/7607bba8-30e0-48bb-9ead-da49f09f37f1">
<img width="376" alt="image" src="https://github.com/Java-and-Script/pickple-front/assets/87280835/e1278e58-66b3-4cb5-bbc4-ddd6944bc592">


<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
