### PR TITLE
크루 참여 취소하기 렌더링 안되는 버그

### DIFF
--- a/src/pages/CrewsDetailPage/components/ParticipateButton.tsx
+++ b/src/pages/CrewsDetailPage/components/ParticipateButton.tsx
@@ -56,14 +56,16 @@ export const ParticipateButton = ({
   }
 
   if (memberRegistrationStatus === '대기') {
-    <Button
-      {...theme.BUTTON_PROPS.LARGE_RED_BUTTON_PROPS}
-      height="50px"
-      width="100%"
-      onClick={() => toast('준비중인 기능입니다')}
-    >
-      참여 취소하기
-    </Button>;
+    return (
+      <Button
+        {...theme.BUTTON_PROPS.LARGE_RED_BUTTON_PROPS}
+        height="50px"
+        width="100%"
+        onClick={() => toast('준비중인 기능입니다')}
+      >
+        참여 취소하기
+      </Button>
+    );
   }
 
   return null;

--- a/src/pages/WebViewPage/WebViewPage.tsx
+++ b/src/pages/WebViewPage/WebViewPage.tsx
@@ -7,6 +7,7 @@ import { theme } from '@styles/theme';
 import GithubIcon from '@assets/githubIcon.svg?react';
 import Logo from '@assets/logoSvg.svg?react';
 import NotionIcon from '@assets/notionIcon.svg?react';
+import QRIconPng from '@assets/qrIcon.png';
 import * as webViewImg from '@assets/webView';
 import Filter from '@assets/webView/solvingProblem/filter.svg?react';
 import Lock from '@assets/webView/solvingProblem/lock.svg?react';
@@ -71,7 +72,7 @@ export const WebViewPage = () => {
                   )
                 }
               />
-              <QRIcon />
+              <QRIcon url={QRIconPng} />
             </IconWrapper>
           </FontContainer>
           <PhoneMockup>
@@ -418,10 +419,10 @@ const Img = styled.img`
     }
   }
 `;
-const QRIcon = styled.div`
+const QRIcon = styled.div<{ url: string }>`
   width: 56px;
   height: 56px;
-  background-image: url('src/assets/qrIcon.png');
+  background-image: url(${({ url }) => url});
   background-repeat: no-repeat;
   background-size: contain;
 `;


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
크루 참여 취소하기 렌더링 안되는 버그

## 👨‍💻 구현 내용 or 👍 해결 내용
조건부 렌더링 리턴이 없어서 렌더링이 안되더라구요
[fix: 크루 참여 취소하기 버튼 렌더링 안되던 것 수정](https://github.com/Java-and-Script/pickple-front/commit/346e3ea1c00f5d8b98ca4e24028fb34f12f96179)

<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
