### PR TITLE
채팅방 페이지에서 페이지 이동 시 스크롤이 안 먹는 버그

### DIFF
--- a/src/hooks/chats/useAllChatRoomListQuery.ts
+++ b/src/hooks/chats/useAllChatRoomListQuery.ts
@@ -11,6 +11,6 @@ export const useAllChatRoomListQuery = ({
     queryKey: ['all-chat-room-list', type],
     queryFn: () => getAllChatRoomList({ type }),
     refetchOnMount: 'always',
-    refetchInterval: 10000,
+    refetchInterval: 3000,
   });
 };

--- a/src/pages/ChattingPage/hooks/useChattingPage.ts
+++ b/src/pages/ChattingPage/hooks/useChattingPage.ts
@@ -182,6 +182,7 @@ export const useChattingPage = () => {
   };
 
   const moveToPage = (path: string) => {
+    flushSync(() => setIsModalOpen(false));
     navigate(path);
   };
 


### PR DESCRIPTION
## ⚙️ PR 타입

- [ ] Feature
- [x] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
채팅방 페이지에서 페이지 이동 시 스크롤이 안 먹는 버그를 수정했습니다.
채팅방 목록을 refetch 해오는 간격도 3초로 줄였습니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[fix: 페이지 이동 시 모달 닫기 추가](https://github.com/Java-and-Script/pickple-front/commit/91b643b952c554a0ef79144c439ef0cf7fc52815)
 
[fix: 채팅 목록 refetch 간격 수정](https://github.com/Java-and-Script/pickple-front/commit/2fc40f3153c1fbe7549f68052b9c5a2d3f9cf181)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
