### PR TITLE
크루, 게스트 모집 상세 페이지 하단버튼 없을 때 padding 제거

### DIFF
--- a/src/pages/CrewsDetailPage/CrewsDetailPage.styles.ts
+++ b/src/pages/CrewsDetailPage/CrewsDetailPage.styles.ts
@@ -71,11 +71,14 @@ export const InfoItem = styled.div`
 
 export const ButtonWrapper = styled.div`
   position: fixed;
-  padding: 5px 16px;
   background-color: white;
   width: 100dvw;
   bottom: 70px;
   left: 0;
+  & > button {
+    width: calc(100% - 32px);
+    margin: 5px 16px;
+  }
 `;
 
 export const AvatarWrapper = styled(Flex)`

--- a/src/pages/GamesDetailPage/GamesDetailPage.styles.ts
+++ b/src/pages/GamesDetailPage/GamesDetailPage.styles.ts
@@ -70,12 +70,15 @@ export const GuestName = styled(Text)`
 
 export const ButtonWrapper = styled.div`
   position: fixed;
-  padding: 5px 16px;
   background-color: white;
   width: 100dvw;
   bottom: 70px;
   left: 0;
   z-index: 1;
+  & > button {
+    width: calc(100% - 32px);
+    margin: 5px 16px;
+  }
 `;
 
 export const PositionItemBox = styled.div`


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
크루, 게스트 모집 상세 페이지 하단버튼 없을 때 padding 제거

## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: 크루, 게스트 모집 상세 페이지 하단버튼 없을 때 padding 제거](https://github.com/Java-and-Script/pickple-front/commit/9efa3cd0f9d50e5cb2ce01001aaafcca03cf0052)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
