### PR TITLE
웹뷰에서 모바일뷰 볼 수 있는 버튼 구현

### DIFF
--- a/src/pages/WebViewPage/WebViewPage.tsx
+++ b/src/pages/WebViewPage/WebViewPage.tsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled';
 
+import { Button } from '@components/shared/Button';
+
 import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
 
+import { BUTTON_PROPS } from '@styles/button';
 import { theme } from '@styles/theme';
 
 import GithubIcon from '@assets/githubIcon.svg?react';
@@ -59,6 +62,20 @@ export const WebViewPage = () => {
               <Light>번거로운 과정없이</Light>
               <Light>경기에만 집중하게 해드릴게요</Light>
             </FontWrapper>
+            <Button
+              {...BUTTON_PROPS.LARGE_RED_BUTTON_PROPS}
+              height="50px"
+              width="100%"
+              onClick={() => {
+                window.open(
+                  'https://pickple.kr',
+                  '_blank',
+                  'width=500, height=700'
+                );
+              }}
+            >
+              체험해보기
+            </Button>
             <IconWrapper>
               <GithubIcon
                 onClick={() =>


### PR DESCRIPTION
## ⚙️ PR 타입

- [x] Feature
- [ ] Hotfix

## ✨ 기능 설명 or 🚨 문제 상황
웹 뷰에서 화면 크기 조절 없이 바로 모바일 뷰를 볼 수 있도록 새 창을 오픈하는 버튼을 추가했습니다.
## 👨‍💻 구현 내용 or 👍 해결 내용
[feat: 픽플 페이지를 새 창으로 오픈하는 이벤트 구현](https://github.com/Java-and-Script/pickple-front/commit/f9eabdea7b44897d3baa3231fbd9fb13f055a04d)
<!-- ## 스크린샷 - UI 관련인 경우 꼭 넣기! -->
<img width="1254" alt="image" src="https://github.com/Java-and-Script/pickple-front/assets/87280835/2d5021b1-e73f-4a60-b60c-a9553eec31a1">

<!-- ## 장애물 - 기능 구현 중 있었던 이슈 -->

## 🎯 PR 포인트

<!--리뷰어가 집중했으면 하는 부분 -->

## 📝 참고 사항

<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## ❓ 궁금한 점

<!-- ## 이슈 번호 - close -->

<!--## 완료 사항-->
